### PR TITLE
Reduced amount of 'info' log messages by introducing new 'status' severity

### DIFF
--- a/app/flesnet/Parameters.cpp
+++ b/app/flesnet/Parameters.cpp
@@ -249,7 +249,11 @@ void Parameters::parse_options(int argc, char* argv[])
 
     logging::add_console(static_cast<severity_level>(log_level));
     if (vm.count("log-file")) {
-        L_(info) << "Logging output to " << log_file;
+        L_(info) << "logging output to " << log_file;
+        if (log_level < 3) {
+            log_level = 3;
+            L_(info) << "increased file log level to " << log_level;
+        }
         logging::add_file(log_file, static_cast<severity_level>(log_level));
     }
 

--- a/contrib/readout
+++ b/contrib/readout
@@ -45,7 +45,7 @@ BASE_EQID[1]=0xF01
 
 PGEN_RATE=1
 
-FLESNET_CFG=(--timeslice-size 100 --overlap-size 1 
+FLESNET_CFG=(-l 2 --timeslice-size 100 --overlap-size 1 
 --in-data-buffer-size-exp 27 --cn-data-buffer-size-exp 27 
 --processor-instances 1 -e './tsclient -c%i -s%s -a')
 

--- a/lib/fles_rdma/InputChannelSender.cpp
+++ b/lib/fles_rdma/InputChannelSender.cpp
@@ -152,6 +152,8 @@ void InputChannelSender::operator()()
         while (connected_ != compute_hostnames_.size()) {
             poll_cm_events();
         }
+        L_(info) << "[i" << input_index_ << "] "
+                 << "connection to compute nodes established";
 
         data_source_.proceed();
         time_begin_ = std::chrono::high_resolution_clock::now();

--- a/lib/fles_rdma/InputChannelSender.cpp
+++ b/lib/fles_rdma/InputChannelSender.cpp
@@ -165,6 +165,10 @@ void InputChannelSender::operator()()
         while (timeslice < max_timeslice_number_ && !abort_) {
             if (try_send_timeslice(timeslice)) {
                 timeslice++;
+                if (timeslice == 1) {
+                    L_(info) << "[i" << input_index_ << "] "
+                             << "first timeslice processed";
+                }
             }
             poll_completion();
             data_source_.proceed();

--- a/lib/fles_rdma/InputChannelSender.cpp
+++ b/lib/fles_rdma/InputChannelSender.cpp
@@ -103,11 +103,11 @@ void InputChannelSender::report_status()
               << human_readable_count(status_data.acked, true) << " ("
               << human_readable_count(rate_data, true, "B/s") << ")";
 
-    L_(info) << "[i" << input_index_ << "]   |"
-             << bar_graph(status_data.vector(), "#x._", 20) << "|"
-             << bar_graph(status_desc.vector(), "#x._", 10) << "| "
-             << human_readable_count(rate_data, true, "B/s") << " ("
-             << human_readable_count(rate_desc, true, "Hz") << ")";
+    L_(status) << "[i" << input_index_ << "]   |"
+               << bar_graph(status_data.vector(), "#x._", 20) << "|"
+               << bar_graph(status_desc.vector(), "#x._", 10) << "| "
+               << human_readable_count(rate_data, true, "B/s") << " ("
+               << human_readable_count(rate_desc, true, "Hz") << ")";
 
     previous_send_buffer_status_desc_ = status_desc;
     previous_send_buffer_status_data_ = status_data;

--- a/lib/fles_rdma/TimesliceBuilder.cpp
+++ b/lib/fles_rdma/TimesliceBuilder.cpp
@@ -42,9 +42,9 @@ void TimesliceBuilder::report_status()
         L_(debug) << "[c" << compute_index_ << "] data "
                   << status_data.percentages() << " (used..free) | "
                   << human_readable_count(status_data.acked, true);
-        L_(info) << "[c" << compute_index_ << "_" << c->index() << "] |"
-                 << bar_graph(status_data.vector(), "#._", 20) << "|"
-                 << bar_graph(status_desc.vector(), "#._", 10) << "| ";
+        L_(status) << "[c" << compute_index_ << "_" << c->index() << "] |"
+                   << bar_graph(status_data.vector(), "#._", 20) << "|"
+                   << bar_graph(status_desc.vector(), "#._", 10) << "| ";
     }
 
     scheduler_.add(std::bind(&TimesliceBuilder::report_status, this),

--- a/lib/fles_rdma/TimesliceBuilder.cpp
+++ b/lib/fles_rdma/TimesliceBuilder.cpp
@@ -71,6 +71,8 @@ void TimesliceBuilder::operator()()
         while (connected_ != num_input_nodes_) {
             poll_cm_events();
         }
+        L_(info) << "[c" << compute_index_ << "] "
+                 << "connection to input nodes established";
 
         time_begin_ = std::chrono::high_resolution_clock::now();
 

--- a/lib/logging/log.cpp
+++ b/lib/logging/log.cpp
@@ -45,7 +45,7 @@ std::string fancy_icon(severity_level level)
     static const char* icons[] = {
         u8"\U0001F463", // alternative: 2767
         u8"\U0001F41B", // alternative: 2761
-        u8"\u2139",     u8"\u26a0", u8"\u2718",
+        u8"\u231B", u8"\u2139", u8"\u26a0", u8"\u2718",
         u8"\U0001F480" // alternative: 26A1, 2762
     };
 
@@ -59,7 +59,7 @@ std::string fancy_icon(severity_level level)
 
 std::ostream& operator<<(std::ostream& strm, severity_level level)
 {
-    static const char* strings[] = {"TRACE",   "DEBUG", "INFO",
+    static const char* strings[] = {"TRACE",   "DEBUG", "STATUS", "INFO",
                                     "WARNING", "ERROR", "FATAL"};
 
     if (static_cast<std::size_t>(level) < sizeof(strings) / sizeof(*strings)) {
@@ -79,6 +79,7 @@ boost::log::formatting_ostream& operator<<(
     static const char* colors[] = {
         __ansi(__ansi_faint),
         __ansi(__ansi_color_fg_normal(__ansi_color_green) ";" __ansi_faint),
+        __ansi(__ansi_color_fg_normal(__ansi_color_green)),
         __ansi(__ansi_color_fg_normal(__ansi_color_blue)),
         __ansi(__ansi_color_fg_normal(__ansi_color_yellow)),
         __ansi(__ansi_color_fg_normal(__ansi_color_red)),
@@ -188,6 +189,7 @@ void add_syslog(syslog::facility facility, severity_level minimum_severity)
     syslog::custom_severity_mapping<severity_level> mapping("Severity");
     mapping[trace] = syslog::debug;
     mapping[debug] = syslog::debug;
+    mapping[status] = syslog::debug;
     mapping[info] = syslog::info;
     mapping[warning] = syslog::warning;
     mapping[error] = syslog::error;

--- a/lib/logging/log.hpp
+++ b/lib/logging/log.hpp
@@ -5,7 +5,7 @@
 #include <boost/log/sinks/syslog_backend.hpp>
 #include <boost/log/utility/manipulators/to_log.hpp>
 
-enum severity_level { trace, debug, info, warning, error, fatal };
+enum severity_level { trace, debug, status, info, warning, error, fatal };
 
 namespace logging
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,18 +5,21 @@ add_executable(test_Microslice test_Microslice.cpp)
 add_executable(test_RingBuffer test_RingBuffer.cpp)
 add_executable(test_Filter test_Filter.cpp)
 add_executable(test_MicrosliceReceiver test_MicrosliceReceiver.cpp)
+add_executable(test_logging test_logging.cpp)
 
 target_compile_definitions(test_Timeslice PUBLIC BOOST_TEST_DYN_LINK)
 target_compile_definitions(test_Microslice PUBLIC BOOST_TEST_DYN_LINK)
 target_compile_definitions(test_RingBuffer PUBLIC BOOST_TEST_DYN_LINK)
 target_compile_definitions(test_Filter PUBLIC BOOST_TEST_DYN_LINK)
 target_compile_definitions(test_MicrosliceReceiver PUBLIC BOOST_TEST_DYN_LINK)
+target_compile_definitions(test_logging PUBLIC BOOST_TEST_DYN_LINK)
 
 target_include_directories(test_Timeslice SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_include_directories(test_Microslice SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_include_directories(test_RingBuffer SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_include_directories(test_Filter SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_include_directories(test_MicrosliceReceiver SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
+target_include_directories(test_logging SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 
 target_link_libraries(test_Timeslice fles_ipc ${Boost_LIBRARIES})
 target_link_libraries(test_Microslice fles_ipc ${Boost_LIBRARIES})
@@ -26,6 +29,7 @@ target_link_libraries(test_MicrosliceReceiver fles_core fles_ipc logging ${Boost
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_libraries(test_MicrosliceReceiver atomic)
 endif()
+target_link_libraries(test_logging logging ${Boost_LIBRARIES})
 
 add_custom_command(TARGET test_Timeslice POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy
@@ -45,6 +49,7 @@ add_test(NAME test_Microslice COMMAND test_Microslice)
 add_test(NAME test_RingBuffer COMMAND test_RingBuffer)
 add_test(NAME test_Filter COMMAND test_Filter)
 add_test(NAME test_MicrosliceReceiver COMMAND test_MicrosliceReceiver)
+add_test(NAME test_logging COMMAND test_logging)
 
 find_program(BASH_PROGRAM bash)
 if(BASH_PROGRAM)

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -1,0 +1,23 @@
+// Copyright 2016 Dirk Hutter <hutter@compeng.uni-frankfurt.de>
+
+#include "log.hpp"
+#include <string>
+
+int main()
+{
+    unsigned log_level = 0; // 0 == all
+    std::string log_file = "test_logging.log";
+
+    logging::add_console(static_cast<severity_level>(log_level));
+    logging::add_file(log_file, static_cast<severity_level>(log_level));
+
+    L_(trace) << "This is a trace message.";
+    L_(debug) << "This is a debug message.";
+    L_(status) << "This is a status message.";
+    L_(info) << "This is a info message.";
+    L_(warning) << "This is warning message.";
+    L_(error) << "This is an error message.";
+    L_(fatal) << "This is a fatal error message.";
+
+    return 0;
+}


### PR DESCRIPTION
- To reduce messages in 'info' flesnet will log all recurring status messages to 'status'
- Added additional info messages to compensate for missing information when severity is 'info'