### PR TITLE
New feature: create numbered sequence of output archive files

### DIFF
--- a/app/tsclient/Application.cpp
+++ b/app/tsclient/Application.cpp
@@ -35,8 +35,14 @@ Application::Application(Parameters const& par) : par_(par)
     }
 
     if (!par_.output_archive().empty()) {
-        sinks_.push_back(std::unique_ptr<fles::TimesliceSink>(
-            new fles::TimesliceOutputArchive(par_.output_archive())));
+        if (par_.output_archive_size() == SIZE_MAX) {
+            sinks_.push_back(std::unique_ptr<fles::TimesliceSink>(
+                new fles::TimesliceOutputArchive(par_.output_archive())));
+        } else {
+            sinks_.push_back(std::unique_ptr<fles::TimesliceSink>(
+                new fles::TimesliceOutputArchiveSequence(
+                    par_.output_archive(), par_.output_archive_size())));
+        }
     }
 
     if (!par_.publish_address().empty()) {

--- a/app/tsclient/Parameters.cpp
+++ b/app/tsclient/Parameters.cpp
@@ -35,6 +35,10 @@ void Parameters::parse_options(int argc, char* argv[])
              "name of an input file archive to read");
     desc_add("output-archive,o", po::value<std::string>(&output_archive_),
              "name of an output file archive to write");
+    desc_add("output-archive-size", po::value<size_t>(&output_archive_size_),
+             "limit number of timeslices per file to given number, create "
+             "sequence of output archive files (use placeholder %n in "
+             "output-archive parameter)");
     desc_add("publish,P", po::value<std::string>(&publish_address_)
                               ->implicit_value("tcp://*:5556"),
              "enable timeslice publisher on given address");

--- a/app/tsclient/Parameters.hpp
+++ b/app/tsclient/Parameters.hpp
@@ -32,6 +32,8 @@ public:
 
     std::string output_archive() const { return output_archive_; }
 
+    size_t output_archive_size() const { return output_archive_size_; }
+
     bool analyze() const { return analyze_; }
 
     bool benchmark() const { return benchmark_; }
@@ -51,6 +53,7 @@ private:
     std::string shm_identifier_;
     std::string input_archive_;
     std::string output_archive_;
+    size_t output_archive_size_ = SIZE_MAX;
     bool analyze_ = false;
     bool benchmark_ = false;
     size_t verbosity_ = 0;

--- a/lib/fles_ipc/MicrosliceOutputArchive.hpp
+++ b/lib/fles_ipc/MicrosliceOutputArchive.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "OutputArchive.hpp"
+#include "OutputArchiveSequence.hpp"
 #include "StorableMicroslice.hpp"
 
 namespace fles
@@ -15,5 +16,9 @@ namespace fles
  */
 using MicrosliceOutputArchive = OutputArchive<Microslice, StorableMicroslice,
                                               ArchiveType::MicrosliceArchive>;
+
+using MicrosliceOutputArchiveSequence =
+    OutputArchiveSequence<Microslice, StorableMicroslice,
+                          ArchiveType::MicrosliceArchive>;
 
 } // namespace fles

--- a/lib/fles_ipc/OutputArchiveSequence.hpp
+++ b/lib/fles_ipc/OutputArchiveSequence.hpp
@@ -1,0 +1,112 @@
+// Copyright 2016 Jan de Cuveland <cmail@cuveland.de>
+/// \file
+/// \brief Defines the fles::OutputArchiveSequence template class.
+#pragma once
+
+#include "ArchiveDescriptor.hpp"
+#include "Sink.hpp"
+#include <boost/algorithm/string.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <string>
+
+namespace fles
+{
+
+/**
+ * \brief The OutputArchiveSequence class serializes data sets to a sequence of
+ * output files.
+ */
+template <class Base, class Derived, ArchiveType archive_type>
+class OutputArchiveSequence : public Sink<Base>
+{
+public:
+    /**
+     * \brief Construct an output archive object, open the first archive file
+     * for writing, and write the archive descriptor. All occurences of the
+     * placeholder "%n" in the filename_template are replaced by a sequence
+     * number.
+     *
+     * \param filename_template File name pattern of the archive files
+     * \param items_per_file    Number of items to store in each file
+     */
+    OutputArchiveSequence(const std::string& filename_template,
+                          std::size_t items_per_file = SIZE_MAX)
+        : filename_template_(filename_template), items_per_file_(items_per_file)
+    {
+        if (items_per_file_ == 0) {
+            items_per_file_ = SIZE_MAX;
+        }
+
+        // append sequence number to file name if missing in template
+        if (items_per_file_ < SIZE_MAX &&
+            filename_template_.find("%n") == std::string::npos) {
+            filename_template_ += ".%n";
+        }
+
+        next_file();
+    }
+
+    /// Delete copy constructor (non-copyable).
+    OutputArchiveSequence(const OutputArchiveSequence&) = delete;
+    /// Delete assignment operator (non-copyable).
+    void operator=(const OutputArchiveSequence&) = delete;
+
+    ~OutputArchiveSequence() override = default;
+
+    /// Store an item.
+    void put(std::shared_ptr<const Base> item) override { do_put(*item); }
+
+    void end_stream() override
+    {
+        oarchive_ = nullptr;
+        ofstream_ = nullptr;
+    }
+
+private:
+    std::unique_ptr<std::ofstream> ofstream_;
+    std::unique_ptr<boost::archive::binary_oarchive> oarchive_;
+    ArchiveDescriptor descriptor_{archive_type};
+
+    std::string filename_template_;
+    std::size_t items_per_file_;
+    std::size_t file_count_ = 0;
+    std::size_t file_item_count_ = 0;
+
+    // TODO(Jan): Solve this without the additional alloc/copy operation
+    void do_put(const Derived& item)
+    {
+        if (file_item_count_ == items_per_file_) {
+            next_file();
+        }
+        *oarchive_ << item;
+        ++file_item_count_;
+    }
+
+    std::string filename(std::size_t n) const
+    {
+        std::ostringstream number;
+        number << std::setw(4) << std::setfill('0') << n;
+        return boost::replace_all_copy(filename_template_, "%n", number.str());
+    }
+
+    void next_file()
+    {
+        oarchive_ = nullptr;
+        ofstream_ = nullptr;
+        ofstream_ = std::unique_ptr<std::ofstream>(
+            new std::ofstream(filename(file_count_), std::ios::binary));
+        oarchive_ = std::unique_ptr<boost::archive::binary_oarchive>(
+            new boost::archive::binary_oarchive(*ofstream_));
+        *oarchive_ << descriptor_;
+
+        ++file_count_;
+        file_item_count_ = 0;
+    }
+};
+
+} // namespace fles

--- a/lib/fles_ipc/TimesliceOutputArchive.hpp
+++ b/lib/fles_ipc/TimesliceOutputArchive.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "OutputArchive.hpp"
+#include "OutputArchiveSequence.hpp"
 #include "StorableTimeslice.hpp"
 
 namespace fles
@@ -15,5 +16,9 @@ namespace fles
  */
 using TimesliceOutputArchive =
     OutputArchive<Timeslice, StorableTimeslice, ArchiveType::TimesliceArchive>;
+
+using TimesliceOutputArchiveSequence =
+    OutputArchiveSequence<Timeslice, StorableTimeslice,
+                          ArchiveType::TimesliceArchive>;
 
 } // namespace fles


### PR DESCRIPTION
This adds basic support for creating a numbered sequence of output archive files instead of a single file. It includes the new OutputArchiveSequence class template and adds a corresponding parameter to the tsclient application.