### PR TITLE
Allow output archive sequencing based on byte size and item count

### DIFF
--- a/app/tsclient/Application.cpp
+++ b/app/tsclient/Application.cpp
@@ -35,13 +35,15 @@ Application::Application(Parameters const& par) : par_(par)
     }
 
     if (!par_.output_archive().empty()) {
-        if (par_.output_archive_size() == SIZE_MAX) {
+        if (par_.output_archive_items() == SIZE_MAX &&
+            par_.output_archive_bytes() == SIZE_MAX) {
             sinks_.push_back(std::unique_ptr<fles::TimesliceSink>(
                 new fles::TimesliceOutputArchive(par_.output_archive())));
         } else {
             sinks_.push_back(std::unique_ptr<fles::TimesliceSink>(
                 new fles::TimesliceOutputArchiveSequence(
-                    par_.output_archive(), par_.output_archive_size())));
+                    par_.output_archive(), par_.output_archive_items(),
+                    par_.output_archive_bytes())));
         }
     }
 

--- a/app/tsclient/Parameters.cpp
+++ b/app/tsclient/Parameters.cpp
@@ -35,8 +35,12 @@ void Parameters::parse_options(int argc, char* argv[])
              "name of an input file archive to read");
     desc_add("output-archive,o", po::value<std::string>(&output_archive_),
              "name of an output file archive to write");
-    desc_add("output-archive-size", po::value<size_t>(&output_archive_size_),
+    desc_add("output-archive-items", po::value<size_t>(&output_archive_items_),
              "limit number of timeslices per file to given number, create "
+             "sequence of output archive files (use placeholder %n in "
+             "output-archive parameter)");
+    desc_add("output-archive-bytes", po::value<size_t>(&output_archive_bytes_),
+             "limit number of bytes per file to given number, create "
              "sequence of output archive files (use placeholder %n in "
              "output-archive parameter)");
     desc_add("publish,P", po::value<std::string>(&publish_address_)

--- a/app/tsclient/Parameters.hpp
+++ b/app/tsclient/Parameters.hpp
@@ -32,7 +32,9 @@ public:
 
     std::string output_archive() const { return output_archive_; }
 
-    size_t output_archive_size() const { return output_archive_size_; }
+    size_t output_archive_items() const { return output_archive_items_; }
+
+    size_t output_archive_bytes() const { return output_archive_bytes_; }
 
     bool analyze() const { return analyze_; }
 
@@ -53,7 +55,8 @@ private:
     std::string shm_identifier_;
     std::string input_archive_;
     std::string output_archive_;
-    size_t output_archive_size_ = SIZE_MAX;
+    size_t output_archive_items_ = SIZE_MAX;
+    size_t output_archive_bytes_ = SIZE_MAX;
     bool analyze_ = false;
     bool benchmark_ = false;
     size_t verbosity_ = 0;


### PR DESCRIPTION
Adds output-archive-items and output-archive-bytes parameters to tsclient application. Removes previous output-archive-size parameter.