### PR TITLE
Harden tsclient's zeromq publisher/subscriber against slow consumers

### DIFF
--- a/app/tsclient/Application.cpp
+++ b/app/tsclient/Application.cpp
@@ -17,7 +17,13 @@ Application::Application(Parameters const& par) : par_(par)
     if (!par_.shm_identifier().empty()) {
         source_.reset(new fles::TimesliceReceiver(par_.shm_identifier()));
     } else if (!par_.input_archive().empty()) {
-        source_.reset(new fles::TimesliceInputArchive(par_.input_archive()));
+        if (par_.input_archive_cycles() <= 1) {
+            source_.reset(
+                new fles::TimesliceInputArchive(par_.input_archive()));
+        } else {
+            source_.reset(new fles::TimesliceInputArchiveLoop(
+                par_.input_archive(), par_.input_archive_cycles()));
+        }
     } else if (!par_.subscribe_address().empty()) {
         source_.reset(new fles::TimesliceSubscriber(par_.subscribe_address()));
     }

--- a/app/tsclient/Application.hpp
+++ b/app/tsclient/Application.hpp
@@ -5,6 +5,7 @@
 #include "Parameters.hpp"
 #include "Sink.hpp"
 #include "TimesliceSource.hpp"
+#include <chrono>
 #include <memory>
 #include <vector>
 
@@ -29,4 +30,7 @@ private:
     std::unique_ptr<Benchmark> benchmark_;
 
     uint64_t count_ = 0;
+    std::chrono::high_resolution_clock::time_point time_begin_;
+
+    void rate_limit_delay() const;
 };

--- a/app/tsclient/Parameters.cpp
+++ b/app/tsclient/Parameters.cpp
@@ -33,6 +33,9 @@ void Parameters::parse_options(int argc, char* argv[])
              "shared memory identifier used for receiving timeslices");
     desc_add("input-archive,i", po::value<std::string>(&input_archive_),
              "name of an input file archive to read");
+    desc_add(
+        "input-archive-cycles", po::value<uint64_t>(&input_archive_cycles_),
+        "repeat reading input archive in a loop (for performance testing)");
     desc_add("output-archive,o", po::value<std::string>(&output_archive_),
              "name of an output file archive to write");
     desc_add("output-archive-items", po::value<size_t>(&output_archive_items_),

--- a/app/tsclient/Parameters.cpp
+++ b/app/tsclient/Parameters.cpp
@@ -55,6 +55,8 @@ void Parameters::parse_options(int argc, char* argv[])
     desc_add("maximum-number,n", po::value<uint64_t>(&maximum_number_),
              "set the maximum number of microslices to process (default: "
              "unlimited)");
+    desc_add("rate-limit", po::value<double>(&rate_limit_),
+             "limit the item rate to given frequency (in Hz)");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);

--- a/app/tsclient/Parameters.hpp
+++ b/app/tsclient/Parameters.hpp
@@ -30,6 +30,8 @@ public:
 
     std::string input_archive() const { return input_archive_; }
 
+    uint64_t input_archive_cycles() const { return input_archive_cycles_; }
+
     std::string output_archive() const { return output_archive_; }
 
     size_t output_archive_items() const { return output_archive_items_; }
@@ -54,6 +56,7 @@ private:
     int32_t client_index_ = -1;
     std::string shm_identifier_;
     std::string input_archive_;
+    uint64_t input_archive_cycles_ = 1;
     std::string output_archive_;
     size_t output_archive_items_ = SIZE_MAX;
     size_t output_archive_bytes_ = SIZE_MAX;

--- a/app/tsclient/Parameters.hpp
+++ b/app/tsclient/Parameters.hpp
@@ -50,6 +50,8 @@ public:
 
     uint64_t maximum_number() const { return maximum_number_; }
 
+    double rate_limit() const { return rate_limit_; }
+
 private:
     void parse_options(int argc, char* argv[]);
 
@@ -66,4 +68,5 @@ private:
     std::string publish_address_;
     std::string subscribe_address_;
     uint64_t maximum_number_ = UINT64_MAX;
+    double rate_limit_ = 0.0;
 };

--- a/lib/fles_ipc/ArchiveDescriptor.hpp
+++ b/lib/fles_ipc/ArchiveDescriptor.hpp
@@ -58,6 +58,8 @@ private:
     /// Provide boost serialization access.
     template <class Base, class Derived, ArchiveType archive_type>
     friend class InputArchive;
+    template <class Base, class Derived, ArchiveType archive_type>
+    friend class InputArchiveLoop;
 
     ArchiveDescriptor(){};
 

--- a/lib/fles_ipc/InputArchiveLoop.hpp
+++ b/lib/fles_ipc/InputArchiveLoop.hpp
@@ -1,0 +1,121 @@
+// Copyright 2013, 2015, 2016 Jan de Cuveland <cmail@cuveland.de>
+/// \file
+/// \brief Defines the fles::InputArchiveLoop template class.
+#pragma once
+
+#include "ArchiveDescriptor.hpp"
+#include "Source.hpp"
+#include <boost/archive/binary_iarchive.hpp>
+#include <fstream>
+#include <memory>
+#include <string>
+
+namespace fles
+{
+
+/**
+ * \brief The InputArchiveLoop class deserializes microslice data sets from an
+ * input file. For testing, it can loop over the file a given number of times.
+ */
+template <class Base, class Derived, ArchiveType archive_type>
+class InputArchiveLoop : public Source<Base>
+{
+public:
+    /**
+     * \brief Construct an input archive object, open the given archive file for
+     * reading, and read the archive descriptor.
+     *
+     * \param filename File name of the archive file
+     * \param cycles   Number of times to loop over the archive file for
+     */
+    InputArchiveLoop(const std::string& filename, uint64_t cycles = 1)
+        : filename_(filename), cycles_(cycles)
+    {
+        init();
+    }
+
+    /// Delete copy constructor (non-copyable).
+    InputArchiveLoop(const InputArchiveLoop&) = delete;
+    /// Delete assignment operator (non-copyable).
+    void operator=(const InputArchiveLoop&) = delete;
+
+    ~InputArchiveLoop() override = default;
+
+    /// Read the next data set.
+    std::unique_ptr<Derived> get()
+    {
+        return std::unique_ptr<Derived>(do_get());
+    };
+
+    /// Retrieve the archive descriptor.
+    const ArchiveDescriptor& descriptor() const { return descriptor_; };
+
+    bool eos() const override { return eos_; }
+
+private:
+    void init()
+    {
+        iarchive_ = nullptr;
+        ifstream_ = nullptr;
+
+        ifstream_ = std::unique_ptr<std::ifstream>(
+            new std::ifstream(filename_.c_str(), std::ios::binary));
+        if (!*ifstream_) {
+            throw std::ios_base::failure("error opening file \"" + filename_ +
+                                         "\"");
+        }
+
+        iarchive_ = std::unique_ptr<boost::archive::binary_iarchive>(
+            new boost::archive::binary_iarchive(*ifstream_));
+
+        *iarchive_ >> descriptor_;
+
+        if (descriptor_.archive_type() != archive_type) {
+            throw std::runtime_error("File \"" + filename_ +
+                                     "\" is not of correct archive type");
+        }
+
+        ++cycle_;
+        archive_has_data_ = false;
+    }
+
+    Derived* do_get() override
+    {
+        if (eos_) {
+            return nullptr;
+        }
+
+        Derived* sts = nullptr;
+        try {
+            sts = new Derived();
+            *iarchive_ >> *sts;
+            archive_has_data_ = true;
+        } catch (boost::archive::archive_exception& e) {
+            if (e.code ==
+                boost::archive::archive_exception::input_stream_error) {
+                delete sts;
+                if (archive_has_data_ && cycle_ < cycles_) {
+                    init();
+                    return do_get();
+                }
+                eos_ = true;
+                return nullptr;
+            }
+            throw;
+        }
+        return sts;
+    }
+
+    std::unique_ptr<std::ifstream> ifstream_;
+    std::unique_ptr<boost::archive::binary_iarchive> iarchive_;
+    ArchiveDescriptor descriptor_;
+
+    std::string filename_;
+    uint64_t cycles_;
+
+    uint64_t cycle_ = 0;
+    bool archive_has_data_ = false;
+    bool eos_ = false;
+};
+
+} // namespace fles

--- a/lib/fles_ipc/MicrosliceInputArchive.hpp
+++ b/lib/fles_ipc/MicrosliceInputArchive.hpp
@@ -5,6 +5,7 @@
 
 #include "ArchiveDescriptor.hpp"
 #include "InputArchive.hpp"
+#include "InputArchiveLoop.hpp"
 
 namespace fles
 {
@@ -18,5 +19,9 @@ class StorableMicroslice;
  */
 using MicrosliceInputArchive = InputArchive<Microslice, StorableMicroslice,
                                             ArchiveType::MicrosliceArchive>;
+
+using MicrosliceInputArchiveLoop =
+    InputArchiveLoop<Microslice, StorableMicroslice,
+                     ArchiveType::MicrosliceArchive>;
 
 } // namespace fles

--- a/lib/fles_ipc/StorableMicroslice.hpp
+++ b/lib/fles_ipc/StorableMicroslice.hpp
@@ -20,6 +20,8 @@ namespace fles
 
 template <class Base, class Derived, ArchiveType archive_type>
 class InputArchive;
+template <class Base, class Derived, ArchiveType archive_type>
+class InputArchiveLoop;
 
 /**
  * \brief The StorableMicroslice class contains the data of a single microslice.
@@ -76,6 +78,8 @@ private:
     friend class boost::serialization::access;
     friend class InputArchive<Microslice, StorableMicroslice,
                               ArchiveType::MicrosliceArchive>;
+    friend class InputArchiveLoop<Microslice, StorableMicroslice,
+                                  ArchiveType::MicrosliceArchive>;
 
     StorableMicroslice();
 

--- a/lib/fles_ipc/StorableTimeslice.hpp
+++ b/lib/fles_ipc/StorableTimeslice.hpp
@@ -21,6 +21,8 @@ namespace fles
 
 template <class Base, class Derived, ArchiveType archive_type>
 class InputArchive;
+template <class Base, class Derived, ArchiveType archive_type>
+class InputArchiveLoop;
 
 /**
  * \brief The StorableTimeslice class contains the data of a single timeslice.
@@ -119,6 +121,8 @@ private:
     friend class boost::serialization::access;
     friend class InputArchive<Timeslice, StorableTimeslice,
                               ArchiveType::TimesliceArchive>;
+    friend class InputArchiveLoop<Timeslice, StorableTimeslice,
+                                  ArchiveType::TimesliceArchive>;
     friend class TimesliceSubscriber;
 
     StorableTimeslice();

--- a/lib/fles_ipc/TimesliceInputArchive.hpp
+++ b/lib/fles_ipc/TimesliceInputArchive.hpp
@@ -5,6 +5,7 @@
 
 #include "ArchiveDescriptor.hpp"
 #include "InputArchive.hpp"
+#include "InputArchiveLoop.hpp"
 
 namespace fles
 {
@@ -18,5 +19,9 @@ class StorableTimeslice;
  */
 using TimesliceInputArchive =
     InputArchive<Timeslice, StorableTimeslice, ArchiveType::TimesliceArchive>;
+
+using TimesliceInputArchiveLoop =
+    InputArchiveLoop<Timeslice, StorableTimeslice,
+                     ArchiveType::TimesliceArchive>;
 
 } // namespace fles

--- a/lib/fles_ipc/TimeslicePublisher.cpp
+++ b/lib/fles_ipc/TimeslicePublisher.cpp
@@ -11,6 +11,7 @@ namespace fles
 
 TimeslicePublisher::TimeslicePublisher(const std::string& address)
 {
+    publisher_.setsockopt(ZMQ_SNDHWM, 1);
     publisher_.bind(address.c_str());
 }
 

--- a/lib/fles_ipc/TimesliceSubscriber.cpp
+++ b/lib/fles_ipc/TimesliceSubscriber.cpp
@@ -7,6 +7,7 @@ namespace fles
 
 TimesliceSubscriber::TimesliceSubscriber(const std::string& address)
 {
+    subscriber_.setsockopt(ZMQ_RCVHWM, 1);
     subscriber_.connect(address.c_str());
     subscriber_.setsockopt(ZMQ_SUBSCRIBE, nullptr, 0);
 }


### PR DESCRIPTION
These changes limit publisher and subscriber buffer sizes to favor dropping items instead of queueing. This should help online monitoring software to work on recent data and prevent extensive memory consumption.

In addition, these changes create an enviroment in which the zeromq publish/subscribe can be tested:
- Add InputArchiveLoop class and input-archive-cycles parameter to tsclient.
- Add rate-limit parameter to tsclient.
