### PR TITLE
Fixes in checkers

### DIFF
--- a/lib/fles_core/MicrosliceAnalyzer.cpp
+++ b/lib/fles_core/MicrosliceAnalyzer.cpp
@@ -111,7 +111,7 @@ bool MicrosliceAnalyzer::check_microslice(const fles::Microslice& ms) {
         out_verbosity_ >= 3) { // full dump for first error
       out_ << "microslice content:\n"
            << MicrosliceDescriptorDump(ms.desc())
-           << BufferDump(ms.content(), ms.desc().size);
+           << BufferDump(ms.content(), ms.desc().size) << std::flush;
     }
     ++microslice_error_count_;
   }

--- a/lib/fles_core/TimesliceAnalyzer.cpp
+++ b/lib/fles_core/TimesliceAnalyzer.cpp
@@ -133,7 +133,8 @@ bool TimesliceAnalyzer::check_timeslice(const fles::Timeslice& ts) {
           out_ << "microslice content:\n"
                << MicrosliceDescriptorDump(ts.get_microslice(c, m).desc())
                << BufferDump(ts.get_microslice(c, m).content(),
-                             ts.get_microslice(c, m).desc().size);
+                             ts.get_microslice(c, m).desc().size)
+               << std::flush;
         }
         ++timeslice_error_count_;
         return false;


### PR DESCRIPTION
Fixes:
- out of bound access in flib pattern checker
- scrambled output in case of MS dumps