### PR TITLE
Client side changes: Component size and multi-input support (from CBMROOT)

### DIFF
--- a/app/tsclient/Application.cpp
+++ b/app/tsclient/Application.cpp
@@ -5,11 +5,11 @@
 #include "TimesliceDebugger.hpp"
 #include "TimesliceInputArchive.hpp"
 #include "TimesliceMultiInputArchive.hpp"
+#include "TimesliceMultiSubscriber.hpp"
 #include "TimesliceOutputArchive.hpp"
 #include "TimeslicePublisher.hpp"
 #include "TimesliceReceiver.hpp"
 #include "TimesliceSubscriber.hpp"
-#include "TimesliceMultiSubscriber.hpp"
 #include "Utility.hpp"
 #include <boost/lexical_cast.hpp>
 #include <thread>
@@ -20,9 +20,9 @@ Application::Application(Parameters const& par) : par_(par) {
   } else if (!par_.input_archive().empty()) {
     if (par_.input_archive_cycles() <= 1) {
       if (par_.multi_input()) {
-        source_.reset(new fles::TimesliceMultiInputArchive(par_.input_archive()));
-      }
-      else {
+        source_.reset(
+            new fles::TimesliceMultiInputArchive(par_.input_archive()));
+      } else {
         source_.reset(new fles::TimesliceInputArchive(par_.input_archive()));
       }
     } else {
@@ -33,8 +33,7 @@ Application::Application(Parameters const& par) : par_(par) {
     if (par_.multi_input()) {
       source_.reset(new fles::TimesliceMultiSubscriber(par_.subscribe_address(),
                                                        par_.subscribe_hwm()));
-    }
-    else {
+    } else {
       source_.reset(new fles::TimesliceSubscriber(par_.subscribe_address(),
                                                   par_.subscribe_hwm()));
     }

--- a/app/tsclient/Application.cpp
+++ b/app/tsclient/Application.cpp
@@ -4,10 +4,12 @@
 #include "TimesliceAnalyzer.hpp"
 #include "TimesliceDebugger.hpp"
 #include "TimesliceInputArchive.hpp"
+#include "TimesliceMultiInputArchive.hpp"
 #include "TimesliceOutputArchive.hpp"
 #include "TimeslicePublisher.hpp"
 #include "TimesliceReceiver.hpp"
 #include "TimesliceSubscriber.hpp"
+#include "TimesliceMultiSubscriber.hpp"
 #include "Utility.hpp"
 #include <boost/lexical_cast.hpp>
 #include <thread>
@@ -17,14 +19,25 @@ Application::Application(Parameters const& par) : par_(par) {
     source_.reset(new fles::TimesliceReceiver(par_.shm_identifier()));
   } else if (!par_.input_archive().empty()) {
     if (par_.input_archive_cycles() <= 1) {
-      source_.reset(new fles::TimesliceInputArchive(par_.input_archive()));
+      if (par_.multi_input()) {
+        source_.reset(new fles::TimesliceMultiInputArchive(par_.input_archive()));
+      }
+      else {
+        source_.reset(new fles::TimesliceInputArchive(par_.input_archive()));
+      }
     } else {
       source_.reset(new fles::TimesliceInputArchiveLoop(
           par_.input_archive(), par_.input_archive_cycles()));
     }
   } else if (!par_.subscribe_address().empty()) {
-    source_.reset(new fles::TimesliceSubscriber(par_.subscribe_address(),
-                                                par_.subscribe_hwm()));
+    if (par_.multi_input()) {
+      source_.reset(new fles::TimesliceMultiSubscriber(par_.subscribe_address(),
+                                                       par_.subscribe_hwm()));
+    }
+    else {
+      source_.reset(new fles::TimesliceSubscriber(par_.subscribe_address(),
+                                                  par_.subscribe_hwm()));
+    }
   }
 
   if (par_.analyze()) {

--- a/app/tsclient/Parameters.cpp
+++ b/app/tsclient/Parameters.cpp
@@ -38,6 +38,9 @@ void Parameters::parse_options(int argc, char* argv[]) {
            "enable microslice histogram data output");
   desc_add("shm-identifier,s", po::value<std::string>(&shm_identifier_),
            "shared memory identifier used for receiving timeslices");
+  desc_add("multi-input,m",
+           po::value<bool>(&multi_input_)->implicit_value(true),
+           "enable/disable multi archive/stream input");
   desc_add("input-archive,i", po::value<std::string>(&input_archive_),
            "name of an input file archive to read");
   desc_add("input-archive-cycles", po::value<uint64_t>(&input_archive_cycles_),
@@ -59,12 +62,14 @@ void Parameters::parse_options(int argc, char* argv[]) {
   desc_add("publish-hwm", po::value<uint32_t>(&publish_hwm_),
            "High-water mark for the publisher, in TS, TS drop happens if more "
            "buffered (default: 1)");
+  L_(info) << "Load option HwPublish " << publish_hwm_;
   desc_add("subscribe,S", po::value<std::string>(&subscribe_address_)
                               ->implicit_value("tcp://localhost:5556"),
            "subscribe to timeslice publisher on given address");
   desc_add("subscribe-hwm", po::value<uint32_t>(&subscribe_hwm_),
            "High-water mark for the subscriber, in TS, TS drop happens if more "
            "buffered (default: 1)");
+  L_(info) << "Load option HwSubscribe " << publish_hwm_;
   desc_add("maximum-number,n", po::value<uint64_t>(&maximum_number_),
            "set the maximum number of timeslices to process (default: "
            "unlimited)");

--- a/app/tsclient/Parameters.hpp
+++ b/app/tsclient/Parameters.hpp
@@ -24,6 +24,8 @@ public:
 
   std::string shm_identifier() const { return shm_identifier_; }
 
+  bool multi_input() const { return multi_input_; }
+
   std::string input_archive() const { return input_archive_; }
 
   uint64_t input_archive_cycles() const { return input_archive_cycles_; }
@@ -59,6 +61,7 @@ private:
 
   int32_t client_index_ = -1;
   std::string shm_identifier_;
+  bool multi_input_ = false;
   std::string input_archive_;
   uint64_t input_archive_cycles_ = 1;
   std::string output_archive_;

--- a/lib/fles_ipc/CMakeLists.txt
+++ b/lib/fles_ipc/CMakeLists.txt
@@ -16,4 +16,4 @@ target_include_directories(fles_ipc SYSTEM
   PUBLIC ${PROJECT_SOURCE_DIR}/external/cppzmq
 )
 
-target_link_libraries(fles_ipc PUBLIC ${ZMQ_LIBRARIES})
+target_link_libraries(fles_ipc PUBLIC ${ZMQ_LIBRARIES} PUBLIC logging )

--- a/lib/fles_ipc/Timeslice.hpp
+++ b/lib/fles_ipc/Timeslice.hpp
@@ -45,6 +45,11 @@ public:
     return timeslice_descriptor_.num_components;
   }
 
+  /// Retrieve the size of a given component.
+  uint64_t size_component(uint64_t component) const {
+    return desc_ptr_[component]->size;
+  }
+
   /// Retrieve a pointer to the data content of a given microslice
   const uint8_t* content(uint64_t component, uint64_t microslice) const {
     return data_ptr_[component] +

--- a/lib/fles_ipc/TimesliceMultiInputArchive.cpp
+++ b/lib/fles_ipc/TimesliceMultiInputArchive.cpp
@@ -1,0 +1,191 @@
+// Copyright 2019 Florian Uhlig <f.uhlig@gsi.de>
+
+#include "TimesliceMultiInputArchive.hpp"
+
+#include "TimesliceInputArchive.hpp"
+#include "StorableTimeslice.hpp"
+
+#include <boost/regex.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+
+namespace filesys = boost::filesystem;
+
+namespace fles {
+  
+TimesliceMultiInputArchive::TimesliceMultiInputArchive(const std::string& inputString, const std::string& inputDirectory)
+{
+
+  std::string newInputString{""};
+  if (!inputDirectory.empty()) {
+    // split the input string at the character ";" which divides the string
+    // into different files/filelists for the different streams
+    std::vector<std::string> inputStreams;
+    boost::split(inputStreams, inputString, [](char c){return c == ';';});
+    for (auto& string: inputStreams) {
+      std::string fullFile = inputDirectory + "/" + string;
+      newInputString += fullFile;
+      newInputString += ";";
+    }  
+    newInputString.pop_back(); // Remove the last ;
+  } else {
+    newInputString = inputString;
+  }
+      
+  if (!newInputString.empty()) {
+    CreateInputFileList(newInputString);
+    for (auto& stream: InputFileList) {
+      std::string file = stream.at(0);
+      stream.erase(stream.begin());
+      source_.push_back(
+        std::unique_ptr<TimesliceInputArchive>(
+          new TimesliceInputArchive(file)));
+      L_(info) << " Open file: " << file;
+    }
+  } else {
+    L_(fatal) << "No input files defined";
+    exit(1);
+  }
+  InitTimesliceArchive(); 
+}
+
+void TimesliceMultiInputArchive::CreateInputFileList(std::string inputString)
+{
+  
+  // split the input string at the character ";" which divides the string
+  // into different files/filelists for the different streams
+  std::vector<std::string> inputStreams;
+  boost::split(inputStreams, inputString, [](char c){return c == ';';});
+
+  // loop over the inputs and extract the file List for
+  // the orresponding input
+  // The filename should contain the full path to the file
+  // The filename can contain the wildcard "*"
+  for (auto& string: inputStreams) {
+    filesys::path p{string};
+    std::string dir = p.parent_path().string();
+    std::string filename = p.filename().string();
+
+    std::vector<std::string> v;
+        
+    // escape "." which have a special meaning in regex
+    // change "*" to ".*" to find any number
+    // e.g. tofget4_hd2018.*.tsa => tofget4_hd2018\..*\.tsa
+    boost::replace_all(filename, ".", "\\.");
+    boost::replace_all(filename, "*", ".*");
+                                                
+    // create regex
+    const boost::regex my_filter(filename);
+                                                                
+    // loop over all files in input directory
+    for ( auto&& x : filesys::directory_iterator( p.parent_path() ) ) {
+       // Skip if not a file
+       if( !boost::filesystem::is_regular_file( x ) ) continue;
+       // Skip if no match
+       // x.path().leaf().string() means get from directory iterator the
+       // current entry as filesys::path, from this extract the leaf
+       // filename or directory name and convert it to a string to be
+       // used in the regex:match
+       boost::smatch what;
+       if( !boost::regex_match( x.path().leaf().string(), what, my_filter ) ) continue;
+
+       v.push_back(x.path().string()); 
+    }
+
+    // sort the files which match the regex in increasing order
+    // (hopefully)
+    std::sort(v.begin(), v.end());  
+    
+    InputFileList.push_back(v);
+  }                                             
+
+  // some dubug output 
+  L_(info) << "Number of input streams: " << InputFileList.size();
+  
+  for (auto& streamList : InputFileList) {
+    L_(info) << "Number of files in Stream: " << streamList.size(); 
+    for (auto& fileList : streamList) {
+      L_(info) << "File: " << fileList; 
+    }
+  }
+}
+
+
+void TimesliceMultiInputArchive::InitTimesliceArchive()
+{
+  timesliceCont.resize(source_.size());
+  
+  int element = 0;
+  for (auto& sourceNr: source_) {
+    if(auto timeslice = sourceNr->get()) {
+      sortedSource_.insert({timeslice->index(), element});
+      timesliceCont.at(element) = std::move(timeslice);
+      element++;
+    } else {
+      L_(fatal) << "Could not read a timeslice from input stream " << element;
+      exit(1);
+    }  
+  }
+}
+
+ Timeslice* TimesliceMultiInputArchive::do_get()
+ {
+   return GetNextTimeslice().release();
+ }
+
+  std::unique_ptr<Timeslice> TimesliceMultiInputArchive::GetNextTimeslice() 
+{
+
+  if (sortedSource_.size()>0) {
+    // take the first element from the set which is the one with the smallest
+    // ts number
+    // (*(sortedSource_.begin())) dereference the std::set iterator to get access to the
+    // contained pair 
+    // afterwards erase the first element of the set 
+    int currentSource  = (*(sortedSource_.begin())).second;
+    sortedSource_.erase(sortedSource_.begin());
+  
+    std::unique_ptr<Timeslice> retTimeslice = std::move(timesliceCont.at(currentSource));
+  
+    if (auto timeslice = source_.at(currentSource)->get()) {
+      sortedSource_.insert({timeslice->index(), currentSource});
+      timesliceCont.at(currentSource) = std::move(timeslice);
+    } else {
+      if (!OpenNextFile(currentSource)) {
+        // if the first file reaches the end stop reading
+      //return std::unique_ptr<const Timeslice>(nullptr);
+      } else {
+        if ( (timeslice = source_.at(currentSource)->get()) ) {
+          sortedSource_.insert({timeslice->index(), currentSource});
+          timesliceCont.at(currentSource) = std::move(timeslice);
+        }
+      }
+    }  
+
+    return retTimeslice;
+  } else {
+    return std::unique_ptr<Timeslice>(nullptr);
+  }  
+}    
+
+bool TimesliceMultiInputArchive::OpenNextFile(int element) 
+{ 
+  // First Close and delete existing source
+  if( nullptr != source_.at(element) ) {
+    delete source_.at(element).release();
+  }
+        
+  if (InputFileList.at(element).size() > 0) {
+    std::string file = InputFileList.at(element).at(0);
+    InputFileList.at(element).erase(InputFileList.at(element).begin());
+    source_.at(element) = std::unique_ptr<TimesliceInputArchive>(
+        new TimesliceInputArchive(file));
+    L_(info) << " Open file: " << file;
+  } else {
+    L_(info) << "End of files list reached.";
+    return false;
+  } 
+  return true;
+}
+                                                                                    
+}

--- a/lib/fles_ipc/TimesliceMultiInputArchive.cpp
+++ b/lib/fles_ipc/TimesliceMultiInputArchive.cpp
@@ -16,7 +16,7 @@ namespace fles {
 TimesliceMultiInputArchive::TimesliceMultiInputArchive(
     const std::string& inputString, const std::string& inputDirectory) {
 
-  std::string newInputString{""};
+  std::string newInputString;
   if (!inputDirectory.empty()) {
     // split the input string at the character ";" which divides the string
     // into different files/filelists for the different streams
@@ -78,16 +78,18 @@ void TimesliceMultiInputArchive::CreateInputFileList(std::string inputString) {
     // loop over all files in input directory
     for (auto&& x : filesys::directory_iterator(p.parent_path())) {
       // Skip if not a file
-      if (!boost::filesystem::is_regular_file(x))
+      if (!boost::filesystem::is_regular_file(x)) {
         continue;
+      }
       // Skip if no match
       // x.path().leaf().string() means get from directory iterator the
       // current entry as filesys::path, from this extract the leaf
       // filename or directory name and convert it to a string to be
       // used in the regex:match
       boost::smatch what;
-      if (!boost::regex_match(x.path().leaf().string(), what, my_filter))
+      if (!boost::regex_match(x.path().leaf().string(), what, my_filter)) {
         continue;
+      }
 
       v.push_back(x.path().string());
     }
@@ -132,7 +134,7 @@ Timeslice* TimesliceMultiInputArchive::do_get() {
 
 std::unique_ptr<Timeslice> TimesliceMultiInputArchive::GetNextTimeslice() {
 
-  if (sortedSource_.size() > 0) {
+  if (!sortedSource_.empty()) {
     // take the first element from the set which is the one with the smallest
     // ts number
     // (*(sortedSource_.begin())) dereference the std::set iterator to get
@@ -171,7 +173,7 @@ bool TimesliceMultiInputArchive::OpenNextFile(int element) {
     delete source_.at(element).release();
   }
 
-  if (InputFileList.at(element).size() > 0) {
+  if (!InputFileList.at(element).empty()) {
     std::string file = InputFileList.at(element).at(0);
     InputFileList.at(element).erase(InputFileList.at(element).begin());
     source_.at(element) =

--- a/lib/fles_ipc/TimesliceMultiInputArchive.cpp
+++ b/lib/fles_ipc/TimesliceMultiInputArchive.cpp
@@ -2,43 +2,42 @@
 
 #include "TimesliceMultiInputArchive.hpp"
 
-#include "TimesliceInputArchive.hpp"
 #include "StorableTimeslice.hpp"
+#include "TimesliceInputArchive.hpp"
 
-#include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/regex.hpp>
 
 namespace filesys = boost::filesystem;
 
 namespace fles {
-  
-TimesliceMultiInputArchive::TimesliceMultiInputArchive(const std::string& inputString, const std::string& inputDirectory)
-{
+
+TimesliceMultiInputArchive::TimesliceMultiInputArchive(
+    const std::string& inputString, const std::string& inputDirectory) {
 
   std::string newInputString{""};
   if (!inputDirectory.empty()) {
     // split the input string at the character ";" which divides the string
     // into different files/filelists for the different streams
     std::vector<std::string> inputStreams;
-    boost::split(inputStreams, inputString, [](char c){return c == ';';});
-    for (auto& string: inputStreams) {
+    boost::split(inputStreams, inputString, [](char c) { return c == ';'; });
+    for (auto& string : inputStreams) {
       std::string fullFile = inputDirectory + "/" + string;
       newInputString += fullFile;
       newInputString += ";";
-    }  
+    }
     newInputString.pop_back(); // Remove the last ;
   } else {
     newInputString = inputString;
   }
-      
+
   if (!newInputString.empty()) {
     CreateInputFileList(newInputString);
-    for (auto& stream: InputFileList) {
+    for (auto& stream : InputFileList) {
       std::string file = stream.at(0);
       stream.erase(stream.begin());
-      source_.push_back(
-        std::unique_ptr<TimesliceInputArchive>(
+      source_.push_back(std::unique_ptr<TimesliceInputArchive>(
           new TimesliceInputArchive(file)));
       L_(info) << " Open file: " << file;
     }
@@ -46,146 +45,143 @@ TimesliceMultiInputArchive::TimesliceMultiInputArchive(const std::string& inputS
     L_(fatal) << "No input files defined";
     exit(1);
   }
-  InitTimesliceArchive(); 
+  InitTimesliceArchive();
 }
 
-void TimesliceMultiInputArchive::CreateInputFileList(std::string inputString)
-{
-  
+void TimesliceMultiInputArchive::CreateInputFileList(std::string inputString) {
+
   // split the input string at the character ";" which divides the string
   // into different files/filelists for the different streams
   std::vector<std::string> inputStreams;
-  boost::split(inputStreams, inputString, [](char c){return c == ';';});
+  boost::split(inputStreams, inputString, [](char c) { return c == ';'; });
 
   // loop over the inputs and extract the file List for
   // the orresponding input
   // The filename should contain the full path to the file
   // The filename can contain the wildcard "*"
-  for (auto& string: inputStreams) {
+  for (auto& string : inputStreams) {
     filesys::path p{string};
     std::string dir = p.parent_path().string();
     std::string filename = p.filename().string();
 
     std::vector<std::string> v;
-        
+
     // escape "." which have a special meaning in regex
     // change "*" to ".*" to find any number
     // e.g. tofget4_hd2018.*.tsa => tofget4_hd2018\..*\.tsa
     boost::replace_all(filename, ".", "\\.");
     boost::replace_all(filename, "*", ".*");
-                                                
+
     // create regex
     const boost::regex my_filter(filename);
-                                                                
-    // loop over all files in input directory
-    for ( auto&& x : filesys::directory_iterator( p.parent_path() ) ) {
-       // Skip if not a file
-       if( !boost::filesystem::is_regular_file( x ) ) continue;
-       // Skip if no match
-       // x.path().leaf().string() means get from directory iterator the
-       // current entry as filesys::path, from this extract the leaf
-       // filename or directory name and convert it to a string to be
-       // used in the regex:match
-       boost::smatch what;
-       if( !boost::regex_match( x.path().leaf().string(), what, my_filter ) ) continue;
 
-       v.push_back(x.path().string()); 
+    // loop over all files in input directory
+    for (auto&& x : filesys::directory_iterator(p.parent_path())) {
+      // Skip if not a file
+      if (!boost::filesystem::is_regular_file(x))
+        continue;
+      // Skip if no match
+      // x.path().leaf().string() means get from directory iterator the
+      // current entry as filesys::path, from this extract the leaf
+      // filename or directory name and convert it to a string to be
+      // used in the regex:match
+      boost::smatch what;
+      if (!boost::regex_match(x.path().leaf().string(), what, my_filter))
+        continue;
+
+      v.push_back(x.path().string());
     }
 
     // sort the files which match the regex in increasing order
     // (hopefully)
-    std::sort(v.begin(), v.end());  
-    
-    InputFileList.push_back(v);
-  }                                             
+    std::sort(v.begin(), v.end());
 
-  // some dubug output 
+    InputFileList.push_back(v);
+  }
+
+  // some dubug output
   L_(info) << "Number of input streams: " << InputFileList.size();
-  
+
   for (auto& streamList : InputFileList) {
-    L_(info) << "Number of files in Stream: " << streamList.size(); 
+    L_(info) << "Number of files in Stream: " << streamList.size();
     for (auto& fileList : streamList) {
-      L_(info) << "File: " << fileList; 
+      L_(info) << "File: " << fileList;
     }
   }
 }
 
-
-void TimesliceMultiInputArchive::InitTimesliceArchive()
-{
+void TimesliceMultiInputArchive::InitTimesliceArchive() {
   timesliceCont.resize(source_.size());
-  
+
   int element = 0;
-  for (auto& sourceNr: source_) {
-    if(auto timeslice = sourceNr->get()) {
+  for (auto& sourceNr : source_) {
+    if (auto timeslice = sourceNr->get()) {
       sortedSource_.insert({timeslice->index(), element});
       timesliceCont.at(element) = std::move(timeslice);
       element++;
     } else {
       L_(fatal) << "Could not read a timeslice from input stream " << element;
       exit(1);
-    }  
+    }
   }
 }
 
- Timeslice* TimesliceMultiInputArchive::do_get()
- {
-   return GetNextTimeslice().release();
- }
+Timeslice* TimesliceMultiInputArchive::do_get() {
+  return GetNextTimeslice().release();
+}
 
-  std::unique_ptr<Timeslice> TimesliceMultiInputArchive::GetNextTimeslice() 
-{
+std::unique_ptr<Timeslice> TimesliceMultiInputArchive::GetNextTimeslice() {
 
-  if (sortedSource_.size()>0) {
+  if (sortedSource_.size() > 0) {
     // take the first element from the set which is the one with the smallest
     // ts number
-    // (*(sortedSource_.begin())) dereference the std::set iterator to get access to the
-    // contained pair 
-    // afterwards erase the first element of the set 
-    int currentSource  = (*(sortedSource_.begin())).second;
+    // (*(sortedSource_.begin())) dereference the std::set iterator to get
+    // access to the contained pair afterwards erase the first element of the
+    // set
+    int currentSource = (*(sortedSource_.begin())).second;
     sortedSource_.erase(sortedSource_.begin());
-  
-    std::unique_ptr<Timeslice> retTimeslice = std::move(timesliceCont.at(currentSource));
-  
+
+    std::unique_ptr<Timeslice> retTimeslice =
+        std::move(timesliceCont.at(currentSource));
+
     if (auto timeslice = source_.at(currentSource)->get()) {
       sortedSource_.insert({timeslice->index(), currentSource});
       timesliceCont.at(currentSource) = std::move(timeslice);
     } else {
       if (!OpenNextFile(currentSource)) {
         // if the first file reaches the end stop reading
-      //return std::unique_ptr<const Timeslice>(nullptr);
+        // return std::unique_ptr<const Timeslice>(nullptr);
       } else {
-        if ( (timeslice = source_.at(currentSource)->get()) ) {
+        if ((timeslice = source_.at(currentSource)->get())) {
           sortedSource_.insert({timeslice->index(), currentSource});
           timesliceCont.at(currentSource) = std::move(timeslice);
         }
       }
-    }  
+    }
 
     return retTimeslice;
   } else {
     return std::unique_ptr<Timeslice>(nullptr);
-  }  
-}    
+  }
+}
 
-bool TimesliceMultiInputArchive::OpenNextFile(int element) 
-{ 
+bool TimesliceMultiInputArchive::OpenNextFile(int element) {
   // First Close and delete existing source
-  if( nullptr != source_.at(element) ) {
+  if (nullptr != source_.at(element)) {
     delete source_.at(element).release();
   }
-        
+
   if (InputFileList.at(element).size() > 0) {
     std::string file = InputFileList.at(element).at(0);
     InputFileList.at(element).erase(InputFileList.at(element).begin());
-    source_.at(element) = std::unique_ptr<TimesliceInputArchive>(
-        new TimesliceInputArchive(file));
+    source_.at(element) =
+        std::unique_ptr<TimesliceInputArchive>(new TimesliceInputArchive(file));
     L_(info) << " Open file: " << file;
   } else {
     L_(info) << "End of files list reached.";
     return false;
-  } 
+  }
   return true;
 }
-                                                                                    
-}
+
+} // namespace fles

--- a/lib/fles_ipc/TimesliceMultiInputArchive.cpp
+++ b/lib/fles_ipc/TimesliceMultiInputArchive.cpp
@@ -9,6 +9,19 @@
 #include <boost/filesystem.hpp>
 #include <boost/regex.hpp>
 
+/*
+  Unexpected behaviour (from tests):
+
+  - Throws boost::filesystem::filesystem_error if given filename does not contain
+    a directory (incompatible with plain TimesliceInputArchive)
+  - Throws std::out_of_range if given file does not exist because of the "stream.at(0)"
+    statement in the constructor
+  - Multiple files separated by ";" are merged (sorted by time), while multiple
+    files selected by wildcard are visited in sequence
+  - Non-standard wildcard matching: Only "*", no "?". No way to protect literal "*".
+  - Calls "exit()" on errors instead of throwing an exception
+*/
+
 namespace filesys = boost::filesystem;
 
 namespace fles {
@@ -90,7 +103,6 @@ void TimesliceMultiInputArchive::CreateInputFileList(std::string inputString) {
       if (!boost::regex_match(x.path().leaf().string(), what, my_filter)) {
         continue;
       }
-
       v.push_back(x.path().string());
     }
 

--- a/lib/fles_ipc/TimesliceMultiInputArchive.hpp
+++ b/lib/fles_ipc/TimesliceMultiInputArchive.hpp
@@ -1,0 +1,70 @@
+// Copyright 2019 Florian Uhlig <f.uhlig@gsi.de>
+/// \file
+/// \brief Defines the fles::TimesliceMultiInputArchive class.
+#pragma once
+
+
+#include "TimesliceSource.hpp"
+#include "StorableTimeslice.hpp"
+#include "log.hpp"
+#include <chrono>
+#include <memory>
+#include <vector>
+#include <string>
+#include <set>
+
+namespace fles {
+/**
+ * \brief The TimesliceMultiInputArchive class reads timeslice data from
+ * several TimesliceInputArchives and returns the timslice with the 
+ * smallest index.
+ */
+  class TimesliceMultiInputArchive : public TimesliceSource {
+public:
+  // Construct an input archive object for each of the files passed in the input string
+  // open the archive files for reading, and read the archive descriptors
+  // If a directory is passed as second parameter build first a list of filenames which
+  // contains the full path  
+  explicit TimesliceMultiInputArchive(const std::string&, const std::string& ="");
+
+  /// Delete copy constructor (non-copyable).
+  TimesliceMultiInputArchive(const TimesliceMultiInputArchive&) = delete;
+  /// Delete assignment operator (non-copyable).
+  void operator=(const TimesliceMultiInputArchive&) = delete;
+
+  ~TimesliceMultiInputArchive() override = default;
+
+  /**
+   * \brief Retrieve the next item.
+   *
+   * \return pointer to the item, or nullptr if no more
+   * timeslices available in the input archives
+   */
+  std::unique_ptr<Timeslice> get() {
+    return (GetNextTimeslice());
+  };
+
+  bool eos() const override { return sortedSource_.size() == 0; }
+
+private:
+  Timeslice* do_get() override;
+
+  void InitTimesliceArchive();
+  void CreateInputFileList(std::string);
+  bool OpenNextFile(int);
+  std::unique_ptr<Timeslice> GetNextTimeslice();
+  
+  std::vector<std::unique_ptr<TimesliceSource>> source_;
+
+  std::vector<std::vector<std::string>> InputFileList;
+
+  std::vector<std::unique_ptr<Timeslice>> timesliceCont;
+
+  std::set<std::pair<uint64_t,int>> sortedSource_;
+  
+  logging::OstreamLog status_log_{status};
+  logging::OstreamLog debug_log_{debug};
+
+};
+
+} // namespace fles

--- a/lib/fles_ipc/TimesliceMultiInputArchive.hpp
+++ b/lib/fles_ipc/TimesliceMultiInputArchive.hpp
@@ -3,29 +3,29 @@
 /// \brief Defines the fles::TimesliceMultiInputArchive class.
 #pragma once
 
-
-#include "TimesliceSource.hpp"
 #include "StorableTimeslice.hpp"
+#include "TimesliceSource.hpp"
 #include "log.hpp"
 #include <chrono>
 #include <memory>
-#include <vector>
-#include <string>
 #include <set>
+#include <string>
+#include <vector>
 
 namespace fles {
 /**
  * \brief The TimesliceMultiInputArchive class reads timeslice data from
- * several TimesliceInputArchives and returns the timslice with the 
+ * several TimesliceInputArchives and returns the timslice with the
  * smallest index.
  */
-  class TimesliceMultiInputArchive : public TimesliceSource {
+class TimesliceMultiInputArchive : public TimesliceSource {
 public:
-  // Construct an input archive object for each of the files passed in the input string
-  // open the archive files for reading, and read the archive descriptors
-  // If a directory is passed as second parameter build first a list of filenames which
-  // contains the full path  
-  explicit TimesliceMultiInputArchive(const std::string&, const std::string& ="");
+  // Construct an input archive object for each of the files passed in the input
+  // string open the archive files for reading, and read the archive descriptors
+  // If a directory is passed as second parameter build first a list of
+  // filenames which contains the full path
+  explicit TimesliceMultiInputArchive(const std::string&,
+                                      const std::string& = "");
 
   /// Delete copy constructor (non-copyable).
   TimesliceMultiInputArchive(const TimesliceMultiInputArchive&) = delete;
@@ -40,9 +40,7 @@ public:
    * \return pointer to the item, or nullptr if no more
    * timeslices available in the input archives
    */
-  std::unique_ptr<Timeslice> get() {
-    return (GetNextTimeslice());
-  };
+  std::unique_ptr<Timeslice> get() { return (GetNextTimeslice()); };
 
   bool eos() const override { return sortedSource_.size() == 0; }
 
@@ -53,18 +51,17 @@ private:
   void CreateInputFileList(std::string);
   bool OpenNextFile(int);
   std::unique_ptr<Timeslice> GetNextTimeslice();
-  
+
   std::vector<std::unique_ptr<TimesliceSource>> source_;
 
   std::vector<std::vector<std::string>> InputFileList;
 
   std::vector<std::unique_ptr<Timeslice>> timesliceCont;
 
-  std::set<std::pair<uint64_t,int>> sortedSource_;
-  
+  std::set<std::pair<uint64_t, int>> sortedSource_;
+
   logging::OstreamLog status_log_{status};
   logging::OstreamLog debug_log_{debug};
-
 };
 
 } // namespace fles

--- a/lib/fles_ipc/TimesliceMultiInputArchive.hpp
+++ b/lib/fles_ipc/TimesliceMultiInputArchive.hpp
@@ -24,8 +24,9 @@ public:
   // string open the archive files for reading, and read the archive descriptors
   // If a directory is passed as second parameter build first a list of
   // filenames which contains the full path
-  explicit TimesliceMultiInputArchive(const std::string&,
-                                      const std::string& = "");
+  explicit TimesliceMultiInputArchive(
+      const std::string& /*inputString*/,
+      const std::string& /*inputDirectory*/ = "");
 
   /// Delete copy constructor (non-copyable).
   TimesliceMultiInputArchive(const TimesliceMultiInputArchive&) = delete;
@@ -42,14 +43,14 @@ public:
    */
   std::unique_ptr<Timeslice> get() { return (GetNextTimeslice()); };
 
-  bool eos() const override { return sortedSource_.size() == 0; }
+  bool eos() const override { return sortedSource_.empty(); }
 
 private:
   Timeslice* do_get() override;
 
   void InitTimesliceArchive();
-  void CreateInputFileList(std::string);
-  bool OpenNextFile(int);
+  void CreateInputFileList(std::string /*inputString*/);
+  bool OpenNextFile(int /*element*/);
   std::unique_ptr<Timeslice> GetNextTimeslice();
 
   std::vector<std::unique_ptr<TimesliceSource>> source_;

--- a/lib/fles_ipc/TimesliceMultiSubscriber.cpp
+++ b/lib/fles_ipc/TimesliceMultiSubscriber.cpp
@@ -1,0 +1,130 @@
+// Copyright 2019 Florian Uhlig <f.uhlig@gsi.de>
+
+#include "TimesliceMultiSubscriber.hpp"
+
+#include "TimesliceSubscriber.hpp"
+#include "StorableTimeslice.hpp"
+
+#include <boost/regex.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+
+namespace filesys = boost::filesystem;
+
+namespace fles {
+
+TimesliceMultiSubscriber::TimesliceMultiSubscriber(const std::string& inputString,
+                                                   uint32_t hwm)
+{
+  if (!inputString.empty()) {
+    CreateHostPortFileList(inputString);
+    for (auto& stream: InputHostPortList) {
+      std::string server = stream;
+      source_.push_back(
+        std::unique_ptr<TimesliceSubscriber>(
+          new TimesliceSubscriber(server, hwm)));
+      L_(info) << " Open server: " << server << " with ZMQ HW mark " << hwm;
+    }
+  } else {
+    L_(fatal) << "No server defined";
+    exit(1);
+  }
+  InitTimesliceSubscriber();
+}
+
+void TimesliceMultiSubscriber::CreateHostPortFileList(std::string inputString)
+{
+
+  // split the input string at the character ";" which devides the string
+  // into different file/filelists for the different streams
+  std::vector<std::string> inputStreams;
+  boost::split(inputStreams, inputString, [](char c){return c == ';';});
+
+  // loop over the inputs and extract for each input the host address including eventual port
+  // if not port is defined, add the default port
+  // The hostname cannot contain the wildcard "*"
+  for (auto& string: inputStreams) {
+
+    if( 0 == string.size() )
+      L_(error) << " Empty hostname string, ignoring it";
+
+    std::vector<std::string> stringsHostnamePort;
+    boost::split(stringsHostnamePort, string, [](char c){return c == ':';});
+
+    switch( stringsHostnamePort.size() ) {
+      case 1:
+        string += DefaultPort;
+        break;
+      case 2:
+        break;
+      default:
+        // Bad hostname, ignore it
+        L_(error) << " Bad hostname string: " << string;
+        continue;
+    }
+    std::string fullpath = "tcp://";
+    fullpath += string;
+    InputHostPortList.push_back(fullpath);
+  }
+
+  // some dubug output
+  L_(info) << "Number of input streams: " << InputHostPortList.size();
+
+  for (auto& streamList : InputHostPortList) {
+    L_(info) << "Host and port: " << streamList;
+  }
+}
+
+
+void TimesliceMultiSubscriber::InitTimesliceSubscriber()
+{
+  timesliceCont.resize(source_.size());
+
+  int element = 0;
+  for (auto& sourceNr: source_) {
+    if(auto timeslice = sourceNr->get()) {
+      sortedSource_.insert({timeslice->index(), element});
+      timesliceCont.at(element) = std::move(timeslice);
+      element++;
+    } else {
+      L_(fatal) << "Could not read a timeslice from input stream " << element;
+      exit(1);
+    }
+  }
+}
+
+Timeslice* TimesliceMultiSubscriber::do_get()
+{
+ return GetNextTimeslice().release();
+}
+
+std::unique_ptr<Timeslice> TimesliceMultiSubscriber::GetNextTimeslice()
+{
+
+  if (sortedSource_.size()>0) {
+    // take the first element from the set which is the one with the smallest
+    // ts number
+    // (*(sortedSource_.begin())) dereference the std::set iterator to get access to the
+    // contained pair
+    // afterwards erase the first element of the set
+    int currentSource  = (*(sortedSource_.begin())).second;
+    sortedSource_.erase(sortedSource_.begin());
+
+    std::unique_ptr<Timeslice> retTimeslice = std::move(timesliceCont.at(currentSource));
+
+    if (auto timeslice = source_.at(currentSource)->get()) {
+      sortedSource_.insert({timeslice->index(), currentSource});
+      timesliceCont.at(currentSource) = std::move(timeslice);
+    } else {
+      // When any server stopped sending, stop reading
+      //return std::unique_ptr<const Timeslice>(nullptr);
+    }
+
+    return retTimeslice;
+  } else {
+    return std::unique_ptr<Timeslice>(nullptr);
+  }
+}
+
+} // end of namespace fles

--- a/lib/fles_ipc/TimesliceMultiSubscriber.cpp
+++ b/lib/fles_ipc/TimesliceMultiSubscriber.cpp
@@ -2,27 +2,25 @@
 
 #include "TimesliceMultiSubscriber.hpp"
 
-#include "TimesliceSubscriber.hpp"
 #include "StorableTimeslice.hpp"
+#include "TimesliceSubscriber.hpp"
 
-#include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
+#include <boost/regex.hpp>
 
 namespace filesys = boost::filesystem;
 
 namespace fles {
 
-TimesliceMultiSubscriber::TimesliceMultiSubscriber(const std::string& inputString,
-                                                   uint32_t hwm)
-{
+TimesliceMultiSubscriber::TimesliceMultiSubscriber(
+    const std::string& inputString, uint32_t hwm) {
   if (!inputString.empty()) {
     CreateHostPortFileList(inputString);
-    for (auto& stream: InputHostPortList) {
+    for (auto& stream : InputHostPortList) {
       std::string server = stream;
-      source_.push_back(
-        std::unique_ptr<TimesliceSubscriber>(
+      source_.push_back(std::unique_ptr<TimesliceSubscriber>(
           new TimesliceSubscriber(server, hwm)));
       L_(info) << " Open server: " << server << " with ZMQ HW mark " << hwm;
     }
@@ -33,35 +31,34 @@ TimesliceMultiSubscriber::TimesliceMultiSubscriber(const std::string& inputStrin
   InitTimesliceSubscriber();
 }
 
-void TimesliceMultiSubscriber::CreateHostPortFileList(std::string inputString)
-{
+void TimesliceMultiSubscriber::CreateHostPortFileList(std::string inputString) {
 
   // split the input string at the character ";" which devides the string
   // into different file/filelists for the different streams
   std::vector<std::string> inputStreams;
-  boost::split(inputStreams, inputString, [](char c){return c == ';';});
+  boost::split(inputStreams, inputString, [](char c) { return c == ';'; });
 
-  // loop over the inputs and extract for each input the host address including eventual port
-  // if not port is defined, add the default port
-  // The hostname cannot contain the wildcard "*"
-  for (auto& string: inputStreams) {
+  // loop over the inputs and extract for each input the host address including
+  // eventual port if not port is defined, add the default port The hostname
+  // cannot contain the wildcard "*"
+  for (auto& string : inputStreams) {
 
-    if( 0 == string.size() )
+    if (0 == string.size())
       L_(error) << " Empty hostname string, ignoring it";
 
     std::vector<std::string> stringsHostnamePort;
-    boost::split(stringsHostnamePort, string, [](char c){return c == ':';});
+    boost::split(stringsHostnamePort, string, [](char c) { return c == ':'; });
 
-    switch( stringsHostnamePort.size() ) {
-      case 1:
-        string += DefaultPort;
-        break;
-      case 2:
-        break;
-      default:
-        // Bad hostname, ignore it
-        L_(error) << " Bad hostname string: " << string;
-        continue;
+    switch (stringsHostnamePort.size()) {
+    case 1:
+      string += DefaultPort;
+      break;
+    case 2:
+      break;
+    default:
+      // Bad hostname, ignore it
+      L_(error) << " Bad hostname string: " << string;
+      continue;
     }
     std::string fullpath = "tcp://";
     fullpath += string;
@@ -76,14 +73,12 @@ void TimesliceMultiSubscriber::CreateHostPortFileList(std::string inputString)
   }
 }
 
-
-void TimesliceMultiSubscriber::InitTimesliceSubscriber()
-{
+void TimesliceMultiSubscriber::InitTimesliceSubscriber() {
   timesliceCont.resize(source_.size());
 
   int element = 0;
-  for (auto& sourceNr: source_) {
-    if(auto timeslice = sourceNr->get()) {
+  for (auto& sourceNr : source_) {
+    if (auto timeslice = sourceNr->get()) {
       sortedSource_.insert({timeslice->index(), element});
       timesliceCont.at(element) = std::move(timeslice);
       element++;
@@ -94,31 +89,30 @@ void TimesliceMultiSubscriber::InitTimesliceSubscriber()
   }
 }
 
-Timeslice* TimesliceMultiSubscriber::do_get()
-{
- return GetNextTimeslice().release();
+Timeslice* TimesliceMultiSubscriber::do_get() {
+  return GetNextTimeslice().release();
 }
 
-std::unique_ptr<Timeslice> TimesliceMultiSubscriber::GetNextTimeslice()
-{
+std::unique_ptr<Timeslice> TimesliceMultiSubscriber::GetNextTimeslice() {
 
-  if (sortedSource_.size()>0) {
+  if (sortedSource_.size() > 0) {
     // take the first element from the set which is the one with the smallest
     // ts number
-    // (*(sortedSource_.begin())) dereference the std::set iterator to get access to the
-    // contained pair
-    // afterwards erase the first element of the set
-    int currentSource  = (*(sortedSource_.begin())).second;
+    // (*(sortedSource_.begin())) dereference the std::set iterator to get
+    // access to the contained pair afterwards erase the first element of the
+    // set
+    int currentSource = (*(sortedSource_.begin())).second;
     sortedSource_.erase(sortedSource_.begin());
 
-    std::unique_ptr<Timeslice> retTimeslice = std::move(timesliceCont.at(currentSource));
+    std::unique_ptr<Timeslice> retTimeslice =
+        std::move(timesliceCont.at(currentSource));
 
     if (auto timeslice = source_.at(currentSource)->get()) {
       sortedSource_.insert({timeslice->index(), currentSource});
       timesliceCont.at(currentSource) = std::move(timeslice);
     } else {
       // When any server stopped sending, stop reading
-      //return std::unique_ptr<const Timeslice>(nullptr);
+      // return std::unique_ptr<const Timeslice>(nullptr);
     }
 
     return retTimeslice;

--- a/lib/fles_ipc/TimesliceMultiSubscriber.cpp
+++ b/lib/fles_ipc/TimesliceMultiSubscriber.cpp
@@ -10,8 +10,6 @@
 #include <boost/format.hpp>
 #include <boost/regex.hpp>
 
-namespace filesys = boost::filesystem;
-
 namespace fles {
 
 TimesliceMultiSubscriber::TimesliceMultiSubscriber(
@@ -43,8 +41,9 @@ void TimesliceMultiSubscriber::CreateHostPortFileList(std::string inputString) {
   // cannot contain the wildcard "*"
   for (auto& string : inputStreams) {
 
-    if (0 == string.size())
+    if (string.empty()) {
       L_(error) << " Empty hostname string, ignoring it";
+    }
 
     std::vector<std::string> stringsHostnamePort;
     boost::split(stringsHostnamePort, string, [](char c) { return c == ':'; });
@@ -95,7 +94,7 @@ Timeslice* TimesliceMultiSubscriber::do_get() {
 
 std::unique_ptr<Timeslice> TimesliceMultiSubscriber::GetNextTimeslice() {
 
-  if (sortedSource_.size() > 0) {
+  if (!sortedSource_.empty()) {
     // take the first element from the set which is the one with the smallest
     // ts number
     // (*(sortedSource_.begin())) dereference the std::set iterator to get

--- a/lib/fles_ipc/TimesliceMultiSubscriber.hpp
+++ b/lib/fles_ipc/TimesliceMultiSubscriber.hpp
@@ -3,23 +3,21 @@
 /// \brief Defines the fles::TimesliceMultiSubscriber class.
 #pragma once
 
-
-#include "TimesliceSource.hpp"
 #include "StorableTimeslice.hpp"
+#include "TimesliceSource.hpp"
 #include "log.hpp"
 #include <chrono>
 #include <memory>
-#include <vector>
-#include <string>
 #include <set>
+#include <string>
+#include <vector>
 
 namespace fles {
 /**
- * \brief The TimesliceMultiSubscriber class receives serialized timeslice data from
- * several zeromq socket and returns the timeslice with the
- * smallest index.
+ * \brief The TimesliceMultiSubscriber class receives serialized timeslice data
+ * from several zeromq socket and returns the timeslice with the smallest index.
  */
-  class TimesliceMultiSubscriber : public TimesliceSource {
+class TimesliceMultiSubscriber : public TimesliceSource {
 public:
   /// Construct timeslice subscriber receiving from given ZMQ address.
   explicit TimesliceMultiSubscriber(const std::string&, uint32_t hwm = 1);
@@ -39,9 +37,7 @@ public:
    * \return pointer to the item, or nullptr if no more
    * timeslices available in the input archives
    */
-  std::unique_ptr<Timeslice> get() {
-    return (GetNextTimeslice());
-  };
+  std::unique_ptr<Timeslice> get() { return (GetNextTimeslice()); };
 
   bool eos() const override { return sortedSource_.size() == 0; }
 
@@ -59,11 +55,10 @@ private:
 
   std::vector<std::unique_ptr<Timeslice>> timesliceCont;
 
-  std::set<std::pair<uint64_t,int>> sortedSource_;
+  std::set<std::pair<uint64_t, int>> sortedSource_;
 
   logging::OstreamLog status_log_{status};
   logging::OstreamLog debug_log_{debug};
-
 };
 
 } // namespace fles

--- a/lib/fles_ipc/TimesliceMultiSubscriber.hpp
+++ b/lib/fles_ipc/TimesliceMultiSubscriber.hpp
@@ -20,7 +20,8 @@ namespace fles {
 class TimesliceMultiSubscriber : public TimesliceSource {
 public:
   /// Construct timeslice subscriber receiving from given ZMQ address.
-  explicit TimesliceMultiSubscriber(const std::string&, uint32_t hwm = 1);
+  explicit TimesliceMultiSubscriber(const std::string& /*inputString*/,
+                                    uint32_t hwm = 1);
 
   /// Delete copy constructor (non-copyable).
   TimesliceMultiSubscriber(const TimesliceMultiSubscriber&) = delete;
@@ -39,13 +40,13 @@ public:
    */
   std::unique_ptr<Timeslice> get() { return (GetNextTimeslice()); };
 
-  bool eos() const override { return sortedSource_.size() == 0; }
+  bool eos() const override { return sortedSource_.empty(); }
 
 private:
   Timeslice* do_get() override;
 
   void InitTimesliceSubscriber();
-  void CreateHostPortFileList(std::string);
+  void CreateHostPortFileList(std::string /*inputString*/);
   std::unique_ptr<Timeslice> GetNextTimeslice();
 
   std::vector<std::unique_ptr<TimesliceSource>> source_;

--- a/lib/fles_ipc/TimesliceMultiSubscriber.hpp
+++ b/lib/fles_ipc/TimesliceMultiSubscriber.hpp
@@ -1,0 +1,69 @@
+// Copyright 2019 Florian Uhlig <f.uhlig@gsi.de>
+/// \file
+/// \brief Defines the fles::TimesliceMultiSubscriber class.
+#pragma once
+
+
+#include "TimesliceSource.hpp"
+#include "StorableTimeslice.hpp"
+#include "log.hpp"
+#include <chrono>
+#include <memory>
+#include <vector>
+#include <string>
+#include <set>
+
+namespace fles {
+/**
+ * \brief The TimesliceMultiSubscriber class receives serialized timeslice data from
+ * several zeromq socket and returns the timeslice with the
+ * smallest index.
+ */
+  class TimesliceMultiSubscriber : public TimesliceSource {
+public:
+  /// Construct timeslice subscriber receiving from given ZMQ address.
+  explicit TimesliceMultiSubscriber(const std::string&, uint32_t hwm = 1);
+
+  /// Delete copy constructor (non-copyable).
+  TimesliceMultiSubscriber(const TimesliceMultiSubscriber&) = delete;
+  /// Delete assignment operator (non-copyable).
+  void operator=(const TimesliceMultiSubscriber&) = delete;
+
+  ~TimesliceMultiSubscriber() override = default;
+
+  /**
+   * \brief Retrieve the next item.
+   *
+   * This function blocks if no next item is yet available from all stream.
+   *
+   * \return pointer to the item, or nullptr if no more
+   * timeslices available in the input archives
+   */
+  std::unique_ptr<Timeslice> get() {
+    return (GetNextTimeslice());
+  };
+
+  bool eos() const override { return sortedSource_.size() == 0; }
+
+private:
+  Timeslice* do_get() override;
+
+  void InitTimesliceSubscriber();
+  void CreateHostPortFileList(std::string);
+  std::unique_ptr<Timeslice> GetNextTimeslice();
+
+  std::vector<std::unique_ptr<TimesliceSource>> source_;
+
+  std::string DefaultPort = ":5556";
+  std::vector<std::string> InputHostPortList;
+
+  std::vector<std::unique_ptr<Timeslice>> timesliceCont;
+
+  std::set<std::pair<uint64_t,int>> sortedSource_;
+
+  logging::OstreamLog status_log_{status};
+  logging::OstreamLog debug_log_{debug};
+
+};
+
+} // namespace fles

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(test_MicrosliceReceiver SYSTEM PUBLIC ${Boost_INCLUDE
 target_include_directories(test_logging SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 
 target_link_libraries(test_Timeslice fles_ipc ${Boost_LIBRARIES})
-target_link_libraries(test_TimesliceMultiInputArchive fles_ipc ${Boost_LIBRARIES})
+target_link_libraries(test_TimesliceMultiInputArchive fles_ipc logging ${Boost_LIBRARIES})
 target_link_libraries(test_Microslice fles_ipc ${Boost_LIBRARIES})
 target_link_libraries(test_RingBuffer fles_core ${Boost_LIBRARIES})
 target_link_libraries(test_Filter fles_core ${Boost_LIBRARIES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(test_MicrosliceReceiver SYSTEM PUBLIC ${Boost_INCLUDE
 target_include_directories(test_logging SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 
 target_link_libraries(test_Timeslice fles_ipc ${Boost_LIBRARIES})
-target_link_libraries(test_TimesliceMultiInputArchive fles_ipc logging ${Boost_LIBRARIES})
+target_link_libraries(test_TimesliceMultiInputArchive fles_ipc logging ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 target_link_libraries(test_Microslice fles_ipc ${Boost_LIBRARIES})
 target_link_libraries(test_RingBuffer fles_core ${Boost_LIBRARIES})
 target_link_libraries(test_Filter fles_core ${Boost_LIBRARIES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright 2015, 2016 Jan de Cuveland <cmail@cuveland.de>
 
 add_executable(test_Timeslice test_Timeslice.cpp)
+add_executable(test_TimesliceMultiInputArchive test_TimesliceMultiInputArchive.cpp)
 add_executable(test_Microslice test_Microslice.cpp)
 add_executable(test_RingBuffer test_RingBuffer.cpp)
 add_executable(test_Filter test_Filter.cpp)
@@ -8,6 +9,7 @@ add_executable(test_MicrosliceReceiver test_MicrosliceReceiver.cpp)
 add_executable(test_logging test_logging.cpp)
 
 target_compile_definitions(test_Timeslice PUBLIC BOOST_TEST_DYN_LINK)
+target_compile_definitions(test_TimesliceMultiInputArchive PUBLIC BOOST_TEST_DYN_LINK)
 target_compile_definitions(test_Microslice PUBLIC BOOST_TEST_DYN_LINK)
 target_compile_definitions(test_RingBuffer PUBLIC BOOST_TEST_DYN_LINK)
 target_compile_definitions(test_Filter PUBLIC BOOST_TEST_DYN_LINK)
@@ -15,6 +17,7 @@ target_compile_definitions(test_MicrosliceReceiver PUBLIC BOOST_TEST_DYN_LINK)
 target_compile_definitions(test_logging PUBLIC BOOST_TEST_DYN_LINK)
 
 target_include_directories(test_Timeslice SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
+target_include_directories(test_TimesliceMultiInputArchive SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_include_directories(test_Microslice SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_include_directories(test_RingBuffer SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 target_include_directories(test_Filter SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
@@ -22,6 +25,7 @@ target_include_directories(test_MicrosliceReceiver SYSTEM PUBLIC ${Boost_INCLUDE
 target_include_directories(test_logging SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 
 target_link_libraries(test_Timeslice fles_ipc ${Boost_LIBRARIES})
+target_link_libraries(test_TimesliceMultiInputArchive fles_ipc ${Boost_LIBRARIES})
 target_link_libraries(test_Microslice fles_ipc ${Boost_LIBRARIES})
 target_link_libraries(test_RingBuffer fles_core ${Boost_LIBRARIES})
 target_link_libraries(test_Filter fles_core ${Boost_LIBRARIES})
@@ -45,6 +49,7 @@ add_custom_command(TARGET test_Filter POST_BUILD
                    $<TARGET_FILE_DIR:test_Filter>)
 
 add_test(NAME test_Timeslice COMMAND test_Timeslice)
+add_test(NAME test_TimesliceMultiInputArchive COMMAND test_TimesliceMultiInputArchive)
 add_test(NAME test_Microslice COMMAND test_Microslice)
 add_test(NAME test_RingBuffer COMMAND test_RingBuffer)
 add_test(NAME test_Filter COMMAND test_Filter)

--- a/test/test_TimesliceMultiInputArchive.cpp
+++ b/test/test_TimesliceMultiInputArchive.cpp
@@ -1,0 +1,33 @@
+// Copyright 2020 Jan de Cuveland <cuveland@compeng.uni-frankfurt.de>
+#define BOOST_TEST_MODULE test_TimesliceMultiInputArchive
+#include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
+
+#include "TimesliceMultiInputArchive.hpp"
+
+BOOST_AUTO_TEST_CASE(archive_exception_test) {
+  std::string filename("./does_not_exist.tsa");
+  BOOST_CHECK_THROW(fles::TimesliceMultiInputArchive source(filename),
+                    std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE(reference_file_existence_test) {
+  std::string filename("./example1.tsa");
+  BOOST_CHECK_NO_THROW(fles::TimesliceMultiInputArchive source(filename));
+}
+
+BOOST_AUTO_TEST_CASE(reference_archive_test) {
+  std::string filename("./example1.tsa;./example1.tsa");
+  uint64_t count = 0;
+  fles::TimesliceMultiInputArchive source(filename);
+  while (auto timeslice = source.get()) {
+    ++count;
+  }
+  BOOST_CHECK_EQUAL(count, 4);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_archive_test) {
+  std::string filename("./example1.msa");
+  BOOST_CHECK_THROW(fles::TimesliceMultiInputArchive source(filename),
+                    std::runtime_error);
+}


### PR DESCRIPTION
Bring back the client size developments/patches done in CBMROOT and used in local flesnet versions for mCBM. These changes were applied until now in CBMROOT by copying files in the fles_ipc folder at build time.

1. Add Component size accessor to Timeslice [FLES IPC]
=> Mostly used for monitoring for now
1. Add classes for multi-input clients [FLES IPC] and support for it in tsclient [TSCLIENT binary]
=> allow things like n-to-m tsa files replaying, n-to-m streams splitting or unpackers in flesnet with multiple builder nodes.

The second change introduces a **dependency of the fles_ipc library on the logging library** which may be replaced by a patch in CBMROOT if undesirable.