### PR TITLE
Include libfabric in default build flow and fix CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      run: make -j
+      run: make
 
     - name: Test
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      run: make
+      run: make -j 32
 
     - name: Test
       working-directory: ${{runner.workspace}}/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ script:
   - make CTEST_OUTPUT_ON_FAILURE=1 test
 
 after_success:
-  - if [ "$CXX" = "g++" ]; then cmake -DCOVERALLS=ON -DCMAKE_BUILD_TYPE=Debug .. && make -j && make coveralls; fi
+  - if [ "$CXX" = "g++" ]; then cmake -DCOVERALLS=ON -DCMAKE_BUILD_TYPE=Debug .. && make -j 32 && make coveralls; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 find_package(Boost 1.65.0 REQUIRED COMPONENTS filesystem log program_options serialization system thread unit_test_framework regex iostreams)
 find_package(Threads REQUIRED)
 
-find_package(LIBFABRIC)
+find_package(LIBFABRIC 1.6 QUIET)
 find_package(RDMA)
 find_package(PDA 11.4.7 EXACT)
 find_package(CPPREST)

--- a/lib/fles_libfabric/ConnectionGroup.hpp
+++ b/lib/fles_libfabric/ConnectionGroup.hpp
@@ -129,7 +129,8 @@ public:
 
   /// The Libfabric completion notification handler.
   int poll_completion() {
-    struct fi_cq_tagged_entry wc[MAX_CQ_ENTRIES];
+    struct fi_cq_tagged_entry* wc =
+        new struct fi_cq_tagged_entry[MAX_CQ_ENTRIES];
     int ne;
     int ne_total = 0;
 

--- a/lib/fles_libfabric/ConnectionGroup.hpp
+++ b/lib/fles_libfabric/ConnectionGroup.hpp
@@ -129,10 +129,7 @@ public:
 
   /// The Libfabric completion notification handler.
   int poll_completion() {
-    // TODO detect the number of messages that we are waiting for
-    const int ne_max = conn_.size() * conn_.size() * 1000;
-
-    struct fi_cq_tagged_entry wc[ne_max];
+    struct fi_cq_tagged_entry wc[MAX_CQ_ENTRIES];
     int ne;
     int ne_total = 0;
 
@@ -141,7 +138,7 @@ public:
 
     for (uint16_t i = 0; i < MAX_CQ_INSTANCE; i++) {
       start = std::chrono::high_resolution_clock::now();
-      ne = fi_cq_read(cqs_[i], wc, ne_max);
+      ne = fi_cq_read(cqs_[i], wc, MAX_CQ_ENTRIES);
       if (ne != 0) {
         /// LOGGING
         end = std::chrono::high_resolution_clock::now();
@@ -448,5 +445,8 @@ private:
   uint64_t agg_CQ_count_ = 0;
 
   uint64_t agg_CQ_COMP_time_ = 0;
+
+  // TODO detect the number of messages that we are waiting for
+  const int MAX_CQ_ENTRIES = 1000;
 };
 } // namespace tl_libfabric

--- a/lib/fles_libfabric/providers/LibfabricCollective.cpp
+++ b/lib/fles_libfabric/providers/LibfabricCollective.cpp
@@ -237,7 +237,7 @@ bool LibfabricCollective::deactive_endpoint(uint32_t index) {
 }
 void LibfabricCollective::wait_for_cq(struct fid_cq* cq, const int32_t events) {
 
-  struct fi_cq_entry wc[MAX_CQ_ENTRIES];
+  struct fi_cq_entry* wc = new struct fi_cq_entry[MAX_CQ_ENTRIES];
   int ne, received = 0, expected = std::min(MAX_CQ_ENTRIES, events),
           remaining = events - MAX_CQ_ENTRIES;
 

--- a/lib/fles_libfabric/providers/LibfabricCollective.hpp
+++ b/lib/fles_libfabric/providers/LibfabricCollective.hpp
@@ -76,5 +76,6 @@ private:
   struct fid_cq* send_cq_ = nullptr;
   struct fid_av* av_ = nullptr;
   const uint32_t num_cqe_ = 1000000;
+  const int MAX_CQ_ENTRIES = 1000;
 };
 } // namespace tl_libfabric

--- a/lib/fles_libfabric/providers/LibfabricCollective.hpp
+++ b/lib/fles_libfabric/providers/LibfabricCollective.hpp
@@ -14,7 +14,7 @@
 #include "log.hpp"
 
 #include <rdma/fabric.h>
-#include <rdma/fi_collective.h>
+//#include <rdma/fi_collective.h>
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_errno.h>
@@ -45,7 +45,6 @@ protected:
   std::vector<struct LibfabricCollectiveEPInfo*> retrieve_endpoint_list();
 
 private:
-
   void initialize_cq(struct fid_cq** cq);
 
   void initialize_av();


### PR DESCRIPTION
When fles_libfabric is included, the build always fails. The reason is an error related to 'out of memory' errors. I propose limiting parallel processes up to 32