### PR TITLE
Add missing dependency in StorableTimeslice

### DIFF
--- a/lib/fles_ipc/StorableTimeslice.cpp
+++ b/lib/fles_ipc/StorableTimeslice.cpp
@@ -2,6 +2,8 @@
 
 #include "StorableTimeslice.hpp"
 
+#include <algorithm>
+
 namespace fles {
 
 StorableTimeslice::StorableTimeslice(const StorableTimeslice& ts)


### PR DESCRIPTION
I got the problem on Ubuntu 20.04 with a FairSoft RC that the compilation of IPC in Cbmroot complained about `copy_n` not being defined.

It seems that the dependency on `algorithm` was previously implicitly fulfilled from another header, probably in boost.

Problem was found in master but could also be applied to `dev_cri` from the `AlgoDepStorTs` in my fork