### PR TITLE
Make InitTimesliceSubscriber call optional in MultiSubscriber constru…

### DIFF
--- a/app/tsclient/Application.cpp
+++ b/app/tsclient/Application.cpp
@@ -40,7 +40,8 @@ Application::Application(Parameters const& par) : par_(par) {
   } else if (!par_.subscribe_address().empty()) {
     if (par_.multi_input()) {
       source_.reset(new fles::TimesliceMultiSubscriber(par_.subscribe_address(),
-                                                       par_.subscribe_hwm()));
+                                                       par_.subscribe_hwm(),
+                                                       true));
     } else {
       source_.reset(new fles::TimesliceSubscriber(par_.subscribe_address(),
                                                   par_.subscribe_hwm()));

--- a/lib/fles_ipc/TimesliceMultiSubscriber.cpp
+++ b/lib/fles_ipc/TimesliceMultiSubscriber.cpp
@@ -13,7 +13,7 @@
 namespace fles {
 
 TimesliceMultiSubscriber::TimesliceMultiSubscriber(
-    const std::string& inputString, uint32_t hwm) {
+    const std::string& inputString, uint32_t hwm, bool initflag) {
   if (!inputString.empty()) {
     CreateHostPortFileList(inputString);
     for (auto& stream : InputHostPortList) {
@@ -26,7 +26,9 @@ TimesliceMultiSubscriber::TimesliceMultiSubscriber(
     L_(fatal) << "No server defined";
     exit(1);
   }
-  InitTimesliceSubscriber();
+  if (initflag) {
+    InitTimesliceSubscriber();
+  }
 }
 
 void TimesliceMultiSubscriber::CreateHostPortFileList(std::string inputString) {

--- a/lib/fles_ipc/TimesliceMultiSubscriber.hpp
+++ b/lib/fles_ipc/TimesliceMultiSubscriber.hpp
@@ -21,7 +21,8 @@ class TimesliceMultiSubscriber : public TimesliceSource {
 public:
   /// Construct timeslice subscriber receiving from given ZMQ address.
   explicit TimesliceMultiSubscriber(const std::string& /*inputString*/,
-                                    uint32_t hwm = 1);
+                                    uint32_t hwm = 1,
+                                    bool initflag = false);
 
   /// Delete copy constructor (non-copyable).
   TimesliceMultiSubscriber(const TimesliceMultiSubscriber&) = delete;
@@ -42,10 +43,11 @@ public:
 
   bool eos() const override { return sortedSource_.empty(); }
 
+  void InitTimesliceSubscriber();
+
 private:
   Timeslice* do_get() override;
 
-  void InitTimesliceSubscriber();
   void CreateHostPortFileList(std::string /*inputString*/);
   std::unique_ptr<Timeslice> GetNextTimeslice();
 


### PR DESCRIPTION
…ctor

- Make it public
- Add a control flag to constructor with default `false` and make `InitTimesliceSubscriber` call in constructor toggled by it
- Add `true` flag to all classes/apps using the MultiSubscriber to have same behavior as before

Replaces the [Cbmroot patch to fles IPC](https://git.cbm.gsi.de/computing/cbmroot/-/blob/master/external/ipc/TimesliceMultiSubscriber_init.patch)
Needed to have proper state sequence in the Cbmroot MQ sampler device (splitting of creation and initialization).