### PR TITLE
Add start_time accessor to Timeslice class

### DIFF
--- a/lib/fles_ipc/Timeslice.hpp
+++ b/lib/fles_ipc/Timeslice.hpp
@@ -85,6 +85,14 @@ public:
     return MicrosliceView(dd, cc);
   }
 
+  /// Retrieve the offical start time of the timeslice
+  uint64_t start_time() const {
+    if (num_components() != 0 && num_microslices(0) != 0) {
+      return descriptor(0, 0).idx;
+    } else
+      return 0;
+  }
+
 protected:
   Timeslice() = default;
 

--- a/test/test_Timeslice.cpp
+++ b/test/test_Timeslice.cpp
@@ -78,6 +78,10 @@ BOOST_FIXTURE_TEST_CASE(content_access_test, F) {
   BOOST_CHECK_EQUAL(*ts0.content(1, 0), 3);
 }
 
+BOOST_FIXTURE_TEST_CASE(start_time_test, F) {
+  BOOST_CHECK_EQUAL(ts0.start_time(), 1);
+}
+
 BOOST_FIXTURE_TEST_CASE(offset_computation_test, F) {
   fles::StorableTimeslice ts{1};
   ts.append_component(2);


### PR DESCRIPTION
Add a start_time() accessor to the Timeslice class. This allow digis to store their time information relative to the global start time of the time slice.

For now, it just takes the information from the first microslice of the first component. This might change in the future.