### PR TITLE
 Add periodic statistics output to TimesliceAnalyzer

### DIFF
--- a/lib/fles_core/TimesliceAnalyzer.cpp
+++ b/lib/fles_core/TimesliceAnalyzer.cpp
@@ -43,7 +43,7 @@ void TimesliceAnalyzer::put(std::shared_ptr<const fles::Timeslice> timeslice) {
   // output_interval_) of timeslices is reached or a given time has passed
   auto now = std::chrono::system_clock::now();
   if ((timeslice_count_ % output_interval_) == 0 ||
-      previous_output_time_ + output_time_interval_ >= now) {
+      previous_output_time_ + output_time_interval_ <= now) {
     print(statistics(), "* ");
     previous_output_time_ = now;
   }

--- a/lib/fles_core/TimesliceAnalyzer.hpp
+++ b/lib/fles_core/TimesliceAnalyzer.hpp
@@ -5,6 +5,7 @@
 #include "Sink.hpp"
 #include "Timeslice.hpp"
 #include "interface.h" // crcutil_interface
+#include <chrono>
 #include <memory>
 #include <optional>
 #include <ostream>
@@ -61,6 +62,8 @@ private:
   std::ostream& out_;
   std::string output_prefix_;
   std::ostream* hist_;
+  std::chrono::system_clock::time_point previous_output_time_;
+  static constexpr std::chrono::seconds output_time_interval_{1};
 
   size_t timeslice_count_ = 0;
   size_t timeslice_error_count_ = 0;


### PR DESCRIPTION
The TimesliceAnalyzer statistics output is additionally triggered at least every second. This provides better insight in online operation with large timeslices.