### PR TITLE
Add thread names to ease debugging

### DIFF
--- a/app/flesnet/Application.cpp
+++ b/app/flesnet/Application.cpp
@@ -248,26 +248,42 @@ void Application::run() {
   for (auto& buffer : timeslice_builders_) {
     boost::packaged_task<void> task(std::ref(*buffer));
     futures.push_back(task.get_future());
-    threads.add_thread(new boost::thread(std::move(task)));
+    auto* thread = new boost::thread(std::move(task));
+#if defined(HAVE_PTHREAD_SETNAME_NP)
+    pthread_setname_np(thread->native_handle(), buffer->thread_name().c_str());
+#endif
+    threads.add_thread(thread);
   }
 
   for (auto& buffer : input_channel_senders_) {
     boost::packaged_task<void> task(std::ref(*buffer));
     futures.push_back(task.get_future());
-    threads.add_thread(new boost::thread(std::move(task)));
+    auto* thread = new boost::thread(std::move(task));
+#if defined(HAVE_PTHREAD_SETNAME_NP)
+    pthread_setname_np(thread->native_handle(), buffer->thread_name().c_str());
+#endif
+    threads.add_thread(thread);
   }
 #endif
 
   for (auto& buffer : timeslice_builders_zeromq_) {
     boost::packaged_task<void> task(std::ref(*buffer));
     futures.push_back(task.get_future());
-    threads.add_thread(new boost::thread(std::move(task)));
+    auto* thread = new boost::thread(std::move(task));
+#if defined(HAVE_PTHREAD_SETNAME_NP)
+    pthread_setname_np(thread->native_handle(), buffer->thread_name().c_str());
+#endif
+    threads.add_thread(thread);
   }
 
   for (auto& buffer : component_senders_zeromq_) {
     boost::packaged_task<void> task(std::ref(*buffer));
     futures.push_back(task.get_future());
-    threads.add_thread(new boost::thread(std::move(task)));
+    auto* thread = new boost::thread(std::move(task));
+#if defined(HAVE_PTHREAD_SETNAME_NP)
+    pthread_setname_np(thread->native_handle(), buffer->thread_name().c_str());
+#endif
+    threads.add_thread(thread);
   }
 
   L_(debug) << "threads started: " << threads.size();

--- a/app/flesnet/CMakeLists.txt
+++ b/app/flesnet/CMakeLists.txt
@@ -36,6 +36,7 @@ if (USE_LIBFABRIC AND LIBFABRIC_FOUND)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_compile_definitions(flesnet PUBLIC HAVE_PTHREAD_SETNAME_NP)
   target_link_libraries(flesnet rt atomic)
 endif()
 

--- a/lib/fles_core/ConnectionGroupWorker.hpp
+++ b/lib/fles_core/ConnectionGroupWorker.hpp
@@ -12,5 +12,14 @@ class ConnectionGroupWorker : public ThreadContainer {
 public:
   /// The "main" function of an IBConnectionGroup & ConnectionGroup decendant.
   virtual void operator()() = 0;
+
+  /**
+   * @brief Return a text description of the object (to be used as a thread
+   * name).
+   *
+   * @return A string describing the object (at most 15 characters long).
+   */
+  [[nodiscard]] virtual std::string thread_name() const { return "CGWorker"; };
+
   virtual ~ConnectionGroupWorker() = default;
 };

--- a/lib/fles_rdma/InputChannelSender.hpp
+++ b/lib/fles_rdma/InputChannelSender.hpp
@@ -40,6 +40,10 @@ public:
 
   void operator()() override;
 
+  [[nodiscard]] std::string thread_name() const override {
+    return "ICS/RDMA/i" + std::to_string(input_index_);
+  };
+
   /// The central function for distributing timeslice data.
   bool try_send_timeslice(uint64_t timeslice);
 

--- a/lib/fles_rdma/TimesliceBuilder.hpp
+++ b/lib/fles_rdma/TimesliceBuilder.hpp
@@ -39,6 +39,10 @@ public:
 
   void operator()() override;
 
+  [[nodiscard]] std::string thread_name() const override {
+    return "TSB/RDMA/o" + std::to_string(compute_index_);
+  };
+
   /// Handle RDMA_CM_EVENT_CONNECT_REQUEST event.
   void on_connect_request(struct rdma_cm_event* event) override;
 

--- a/lib/fles_zeromq/ComponentSenderZeromq.hpp
+++ b/lib/fles_zeromq/ComponentSenderZeromq.hpp
@@ -36,6 +36,16 @@ public:
   /// The thread main function.
   void operator()();
 
+  /**
+   * @brief Return a text description of the object (to be used as a thread
+   * name).
+   *
+   * @return A string describing the object (at most 15 characters long).
+   */
+  [[nodiscard]] std::string thread_name() const {
+    return "CS/ZMQ/i" + std::to_string(input_index_);
+  };
+
   friend void enqueue_ack(void* data, void* hint);
 
 private:

--- a/lib/fles_zeromq/TimesliceBuilderZeromq.hpp
+++ b/lib/fles_zeromq/TimesliceBuilderZeromq.hpp
@@ -8,14 +8,16 @@
 #include <boost/format.hpp>
 #include <cassert>
 #include <csignal>
+#include <string>
 #include <vector>
 #include <zmq.h>
 
-/// Timeslice builder class.
-/** A TimesliceBuilderZeromq object initiates connections to input nodes
- * and
- * receives
- * timeslices to a timeslice buffer. */
+/**
+ * @brief The TimesliceBuilderZeromq class
+ *
+ * A TimesliceBuilderZeromq object initiates connections to input nodes  and
+ * receives timeslices to a timeslice buffer.
+ */
 
 class TimesliceBuilderZeromq {
 public:
@@ -37,6 +39,16 @@ public:
 
   /// The thread main function.
   void operator()();
+
+  /**
+   * @brief Return a text description of the object (to be used as a thread
+   * name).
+   *
+   * @return A string describing the object (at most 15 characters long).
+   */
+  [[nodiscard]] std::string thread_name() const {
+    return "TSB/ZMQ/o" + std::to_string(compute_index_);
+  };
 
 private:
   /// This builder's index in the list of compute nodes.


### PR DESCRIPTION
Under Linux, thread names can be set using pthread_setname_np(). This PR adds support for setting the thread names in the flesnet application, which should ease debugging. The names can be seen, e.g., in gdb (_info threads_) and in htop (_Display options -> Show custom thread names_).

Other systems such as macOS have slightly different mechanisms and are not covered or affected by this change.