### PR TITLE
Fix compilation on macosx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,11 @@ if(INCLUDE_ZMQ)
     GIT_REPOSITORY "https://github.com/zeromq/libzmq.git"
     GIT_TAG "4097855ddaaa65ed7b5e8cb86d143842a594eebd" # v4.3.4
     GIT_CONFIG advice.detachedHead=false
-    CMAKE_CACHE_ARGS -DCMAKE_SUPPRESS_DEVELOPER_WARNINGS:BOOL=TRUE
+    PATCH_COMMAND patch -p1 -i "${CMAKE_SOURCE_DIR}/fix_gnutls_macosx_v4.3.4.patch"
+    CMAKE_CACHE_ARGS
+    -DCMAKE_SUPPRESS_DEVELOPER_WARNINGS:BOOL=TRUE
+    -DWITH_LIBBSD:BOOL=FALSE
+    -DWITH_LIBSODIUM:BOOL=FALSE
     BUILD_COMMAND cmake --build . --target libzmq-static
     BUILD_BYPRODUCTS src/zeromq-build/lib/${CMAKE_STATIC_LIBRARY_PREFIX}zmq${CMAKE_STATIC_LIBRARY_SUFFIX}
     INSTALL_COMMAND ""
@@ -51,11 +55,14 @@ if(INCLUDE_ZMQ)
 
   add_library(zmq::libzmq STATIC IMPORTED GLOBAL)
   add_dependencies(zmq::libzmq zeromq)
-  target_link_libraries(zmq::libzmq
-    INTERFACE gnutls
-    INTERFACE bsd
-    INTERFACE sodium
-  )
+
+  find_package("GnuTLS")
+  if(GNUTLS_FOUND)
+    target_link_libraries(zmq::libzmq
+                          INTERFACE ${GNUTLS_LIBRARIES}
+    )
+  endif()
+
   set_target_properties(zmq::libzmq PROPERTIES
     IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/src/zeromq-build/lib/${CMAKE_STATIC_LIBRARY_PREFIX}zmq${CMAKE_STATIC_LIBRARY_SUFFIX}
     INTERFACE_INCLUDE_DIRECTORIES ${PROJECT_BINARY_DIR}/src/zeromq/include
@@ -121,6 +128,12 @@ find_package(PDA 11.5.7 EXACT)
 find_package(CPPREST)
 find_package(NUMA)
 find_package(Doxygen)
+
+find_package(OpenSSL REQUIRED)
+if(APPLE)
+  find_package(ZSTD)
+  get_filename_component(ZSTD_LIB_DIR ${ZSTD_LIBRARY} DIRECTORY)
+endif()
 
 set(USE_RDMA TRUE CACHE BOOL "Use RDMA libraries and build RDMA transport.")
 if(USE_RDMA AND NOT RDMA_FOUND)
@@ -224,6 +237,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 if(CLANG_TIDY)
   set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY})
 endif()
+
+
 add_subdirectory(app/mstool)
 if(USE_CPPREST AND CPPREST_FOUND)
   add_subdirectory(app/tsclient)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(DEFINED ENV{SIMPATH})
   message(WARNING "SIMPATH set, using Fairroot external packages in build.")
   set(SIMPATH $ENV{SIMPATH})
   set(Boost_NO_SYSTEM_PATHS TRUE)
-  set(BOOST_ROOT $ENV{SIMPATH})
+  set(Boost_ROOT $ENV{SIMPATH})
 endif()
 
 set(INCLUDE_ZMQ FALSE CACHE BOOL "Download, build and statically link ZeroMQ library.")

--- a/app/flesnet/CMakeLists.txt
+++ b/app/flesnet/CMakeLists.txt
@@ -22,8 +22,12 @@ target_include_directories(flesnet SYSTEM PUBLIC
 
 target_link_libraries(flesnet
   flib_ipc fles_core fles_ipc shm_ipc fles_zeromq logging
-  ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${CPPREST_LIBRARY} crypto
+  ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${CPPREST_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY}
 )
+
+if(APPLE)
+  target_link_directories(flesnet PRIVATE ${ZSTD_LIB_DIR})
+endif()
 
 if (USE_RDMA AND RDMA_FOUND)
   target_compile_definitions(flesnet PUBLIC HAVE_RDMA)

--- a/app/mstool/CMakeLists.txt
+++ b/app/mstool/CMakeLists.txt
@@ -19,6 +19,10 @@ target_link_libraries(mstool
   ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
 )
 
+if(APPLE)
+  target_link_directories(mstool PRIVATE ${ZSTD_LIB_DIR})
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_libraries(mstool rt atomic)
 endif()

--- a/app/tsclient/CMakeLists.txt
+++ b/app/tsclient/CMakeLists.txt
@@ -14,6 +14,10 @@ target_link_libraries(tsclient
   ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
 )
 
+if(APPLE)
+  target_link_directories(tsclient PRIVATE ${ZSTD_LIB_DIR})
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_libraries(tsclient rt)
 endif()

--- a/cmake/FindZSTD.cmake
+++ b/cmake/FindZSTD.cmake
@@ -1,0 +1,11 @@
+find_path(ZSTD_INCLUDE_DIR
+  NAMES zstd.h
+)
+
+find_library(ZSTD_LIBRARY
+  NAMES zstd
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ZSTD REQUIRED_VARS ZSTD_LIBRARY ZSTD_INCLUDE_DIR)
+

--- a/fix_gnutls_macosx_v4.3.4.patch
+++ b/fix_gnutls_macosx_v4.3.4.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dd3d8eb9..d887d006 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1351,6 +1351,11 @@ else()
+     target_include_directories(
+       objects PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
++    if(GNUTLS_FOUND)
++      target_include_directories(objects PRIVATE ${GNUTLS_INCLUDE_DIR})
++    endif()
++
++
+   endif()
+ 
+   if(BUILD_SHARED)

--- a/lib/fles_core/CMakeLists.txt
+++ b/lib/fles_core/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(fles_core ${LIB_SOURCES} ${LIB_HEADERS})
 
 target_include_directories(fles_core PUBLIC .)
 
-target_include_directories(fles_core SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
+target_include_directories(fles_core SYSTEM PUBLIC ${Boost_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
 
 if(USE_CPPREST AND CPPREST_FOUND)
   target_include_directories(fles_core SYSTEM PUBLIC ${CPPREST_INCLUDE_DIR})
@@ -26,7 +26,7 @@ target_link_libraries(fles_core
 )
 
 if(USE_CPPREST AND CPPREST_FOUND)
-  target_link_libraries(fles_core PUBLIC ${CPPREST_LIBRARY} crypto)
+  target_link_libraries(fles_core PUBLIC ${CPPREST_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
 endif()
 
 if(USE_NUMA AND NUMA_FOUND)

--- a/lib/shm_ipc/CMakeLists.txt
+++ b/lib/shm_ipc/CMakeLists.txt
@@ -22,3 +22,9 @@ target_link_libraries(shm_ipc
   PUBLIC logging
   PUBLIC zmq::cppzmq
 )
+
+if(GNUTLS_FOUND)
+  target_link_libraries(shm_ipc
+                        INTERFACE ${GNUTLS_LIBRARIES}
+  )
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,7 +40,10 @@ target_link_libraries(test_System fles_ipc ${Boost_LIBRARIES})
 target_link_libraries(test_Utility fles_ipc ${Boost_LIBRARIES})
 target_link_libraries(test_Timeslice fles_ipc ${Boost_LIBRARIES})
 target_link_libraries(test_Archive fles_ipc ${Boost_LIBRARIES})
-target_link_libraries(test_TimesliceAutoSource fles_ipc rt ${Boost_LIBRARIES})
+target_link_libraries(test_TimesliceAutoSource fles_ipc ${Boost_LIBRARIES})
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_libraries(test_TimesliceAutoSource rt)
+endif()
 target_link_libraries(test_TimesliceMultiInputArchive fles_ipc logging ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 target_link_libraries(test_Microslice fles_ipc ${Boost_LIBRARIES})
 target_link_libraries(test_RingBuffer fles_core ${Boost_LIBRARIES})
@@ -50,6 +53,20 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_libraries(test_MicrosliceReceiver atomic)
 endif()
 target_link_libraries(test_logging logging ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+
+if(APPLE)
+  target_link_directories(test_System PRIVATE ${ZSTD_LIB_DIR})
+  target_link_directories(test_Utility PRIVATE ${ZSTD_LIB_DIR})
+  target_link_directories(test_Timeslice PRIVATE ${ZSTD_LIB_DIR})
+  target_link_directories(test_Archive PRIVATE ${ZSTD_LIB_DIR})
+  target_link_directories(test_TimesliceAutoSource PRIVATE ${ZSTD_LIB_DIR})
+  target_link_directories(test_TimesliceMultiInputArchive PRIVATE ${ZSTD_LIB_DIR})
+  target_link_directories(test_Microslice PRIVATE ${ZSTD_LIB_DIR})
+  target_link_directories(test_RingBuffer PRIVATE ${ZSTD_LIB_DIR})
+  target_link_directories(test_Filter PRIVATE ${ZSTD_LIB_DIR})
+  target_link_directories(test_MicrosliceReceiver PRIVATE ${ZSTD_LIB_DIR})
+  target_link_directories(test_logging PRIVATE ${ZSTD_LIB_DIR})
+endif()
 
 add_custom_command(TARGET test_Timeslice POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy
@@ -81,9 +98,11 @@ if(BASH_PROGRAM)
   add_test(NAME test_mstool
            COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test_mstool.sh
            WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-  add_test(NAME test_with_pda
-           COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test_with_pda.sh
-           WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  if (NOT APPLE)
+    add_test(NAME test_with_pda
+             COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test_with_pda.sh
+             WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  endif()
 endif()
 
 add_subdirectory(shm_ipc)


### PR DESCRIPTION
Add a patch for zeromq to properly use the found gnutls during compilation.
Build zeromq without libsodium and libbsd, use internal zeromq code instead.

Check if OpenSSl, gnutls and zstd are installed. Use found paths and
libraries in the project to properly link on macosx.