### PR TITLE
Reduce namespace pollution in the monitoring library

### DIFF
--- a/lib/monitoring/Metric.hpp
+++ b/lib/monitoring/Metric.hpp
@@ -12,36 +12,36 @@
 #include <vector>
 
 namespace cbm {
-using namespace std;
-
-using MetricTagSet = vector<pair<string, string>>;
-using MetricField = variant<bool, int, long, unsigned long, double, string>;
-using MetricFieldSet = vector<pair<string, MetricField>>;
-using sc = chrono::system_clock;
+using MetricTagSet = std::vector<std::pair<std::string, std::string>>;
+using MetricField =
+    std::variant<bool, int, long, unsigned long, double, std::string>;
+using MetricFieldSet = std::vector<std::pair<std::string, MetricField>>;
 
 struct Metric {
+  using time_point = std::chrono::system_clock::time_point;
+
   Metric() = default;
   Metric(const Metric&) = default;
   Metric(Metric&&) = default;
-  Metric(const string& measurement,
+  Metric(const std::string& measurement,
          const MetricTagSet& tagset,
          const MetricFieldSet& fieldset,
-         sc::time_point timestamp = sc::time_point());
-  Metric(const string& measurement,
+         time_point timestamp = time_point());
+  Metric(const std::string& measurement,
          const MetricTagSet& tagset,
          MetricFieldSet&& fieldset,
-         sc::time_point timestamp = sc::time_point());
-  Metric(const string& measurement,
+         time_point timestamp = time_point());
+  Metric(const std::string& measurement,
          MetricTagSet&& tagset,
          MetricFieldSet&& fieldset,
-         sc::time_point timestamp = sc::time_point());
+         time_point timestamp = time_point());
   Metric& operator=(const Metric&) = default;
   Metric& operator=(Metric&&) = default;
 
-  string fMeasurement{""};   //!< measurement name
-  MetricTagSet fTagset;      //!< set of tags
-  MetricFieldSet fFieldset;  //!< set of fields
-  sc::time_point fTimestamp; //!< time stamp
+  std::string fMeasurement{""}; //!< measurement name
+  MetricTagSet fTagset;         //!< set of tags
+  MetricFieldSet fFieldset;     //!< set of fields
+  time_point fTimestamp;        //!< time stamp
 };
 
 } // end namespace cbm

--- a/lib/monitoring/Metric.ipp
+++ b/lib/monitoring/Metric.ipp
@@ -16,10 +16,10 @@ namespace cbm {
   \param timestamp    timestamp (defaults to time of `QueueMetric` when omitted)
  */
 
-inline Metric::Metric(const string& measurement,
+inline Metric::Metric(const std::string& measurement,
                       const MetricTagSet& tagset,
                       const MetricFieldSet& fieldset,
-                      sc::time_point timestamp)
+                      time_point timestamp)
     : fMeasurement(measurement), fTagset(tagset), fFieldset(fieldset),
       fTimestamp(timestamp) {}
 
@@ -31,10 +31,10 @@ inline Metric::Metric(const string& measurement,
   \param timestamp    timestamp (defaults to time of `QueueMetric` when omitted)
  */
 
-inline Metric::Metric(const string& measurement,
+inline Metric::Metric(const std::string& measurement,
                       const MetricTagSet& tagset,
                       MetricFieldSet&& fieldset,
-                      sc::time_point timestamp)
+                      time_point timestamp)
     : fMeasurement(measurement), fTagset(tagset), fFieldset(move(fieldset)),
       fTimestamp(timestamp) {}
 
@@ -46,10 +46,10 @@ inline Metric::Metric(const string& measurement,
   \param timestamp    timestamp (defaults to time of `QueueMetric` when omitted)
  */
 
-inline Metric::Metric(const string& measurement,
+inline Metric::Metric(const std::string& measurement,
                       MetricTagSet&& tagset,
                       MetricFieldSet&& fieldset,
-                      sc::time_point timestamp)
+                      time_point timestamp)
     : fMeasurement(measurement), fTagset(move(tagset)),
       fFieldset(move(fieldset)), fTimestamp(timestamp) {}
 

--- a/lib/monitoring/Monitor.hpp
+++ b/lib/monitoring/Monitor.hpp
@@ -18,69 +18,70 @@
 #include <vector>
 
 namespace cbm {
-using namespace std;
-using namespace std::chrono_literals;
-using sc = chrono::system_clock;
 
 class MonitorSink; // forward declaration
 
 class Monitor {
 public:
-  explicit Monitor(const string& sname = "");
+  using time_point = std::chrono::system_clock::time_point;
+
+  explicit Monitor(const std::string& sname = "");
   virtual ~Monitor();
 
   Monitor(const Monitor&) = delete;
   Monitor& operator=(const Monitor&) = delete;
 
-  void OpenSink(const string& sname);
-  void CloseSink(const string& sname);
-  vector<string> SinkList();
+  void OpenSink(const std::string& sname);
+  void CloseSink(const std::string& sname);
+  std::vector<std::string> SinkList();
 
   void QueueMetric(const Metric& point);
   void QueueMetric(Metric&& point);
-  void QueueMetric(const string& measurement,
+  void QueueMetric(const std::string& measurement,
                    const MetricTagSet& tagset,
                    const MetricFieldSet& fieldset,
-                   sc::time_point timestamp = sc::time_point());
-  void QueueMetric(const string& measurement,
+                   time_point timestamp = time_point());
+  void QueueMetric(const std::string& measurement,
                    const MetricTagSet& tagset,
                    MetricFieldSet&& fieldset,
-                   sc::time_point timestamp = sc::time_point());
-  void QueueMetric(const string& measurement,
+                   time_point timestamp = time_point());
+  void QueueMetric(const std::string& measurement,
                    MetricTagSet&& tagset,
                    MetricFieldSet&& fieldset,
-                   sc::time_point timestamp = sc::time_point());
-  const string& HostName() const;
+                   time_point timestamp = time_point());
+  const std::string& HostName() const;
 
   static Monitor& Ref();
   static Monitor* Ptr();
 
 public:
   // some constants
-  static constexpr auto kELoopTimeout = 10s; //!< monitor flush time
-  static constexpr auto kHeartbeat = 60s;    //!< heartbeat interval
+  static constexpr auto kELoopTimeout =
+      std::chrono::seconds(10); //!< monitor flush time
+  static constexpr auto kHeartbeat =
+      std::chrono::seconds(60); //!< heartbeat interval
 
 private:
   void EventLoop();
-  MonitorSink& SinkRef(const string& sname);
+  MonitorSink& SinkRef(const std::string& sname);
 
 private:
-  using metvec_t = vector<Metric>;
-  using sink_uptr_t = unique_ptr<MonitorSink>;
-  using smap_t = unordered_map<string, sink_uptr_t>;
+  using metvec_t = std::vector<Metric>;
+  using sink_uptr_t = std::unique_ptr<MonitorSink>;
+  using smap_t = std::unordered_map<std::string, sink_uptr_t>;
 
-  thread fThread{};                   //!< worker thread
+  std::thread fThread{};              //!< worker thread
   std::condition_variable fControlCV; //!< condition variable for thread control
   std::mutex fControlMutex{};         //!< mutex for thread control
   bool fStopped{false};               //!< signals thread rundown
 
-  metvec_t fMetVec{};              //!< metric list
-  mutex fMetVecMutex{};            //!< mutex for fMetVec access
-  string fHostName{""};            //!< hostname
-  smap_t fSinkMap{};               //!< sink registry
-  mutex fSinkMapMutex{};           //!< mutex for fSinkMap access
-  sc::time_point fNextHeartbeat{}; //!< time of next heartbeat
-  static Monitor* fpSingleton;     //!< \glos{singleton} this
+  metvec_t fMetVec{};          //!< metric list
+  std::mutex fMetVecMutex{};   //!< mutex for fMetVec access
+  std::string fHostName{""};   //!< hostname
+  smap_t fSinkMap{};           //!< sink registry
+  std::mutex fSinkMapMutex{};  //!< mutex for fSinkMap access
+  time_point fNextHeartbeat{}; //!< time of next heartbeat
+  static Monitor* fpSingleton; //!< \glos{singleton} this
 };
 
 } // end namespace cbm

--- a/lib/monitoring/Monitor.ipp
+++ b/lib/monitoring/Monitor.ipp
@@ -7,7 +7,7 @@ namespace cbm {
 //-----------------------------------------------------------------------------
 //! \brief Returns hostname used by Monitor
 
-inline const string& Monitor::HostName() const { return fHostName; }
+inline const std::string& Monitor::HostName() const { return fHostName; }
 
 //-----------------------------------------------------------------------------
 //! \brief Static method which returns a reference of the

--- a/lib/monitoring/MonitorSink.cpp
+++ b/lib/monitoring/MonitorSink.cpp
@@ -10,7 +10,6 @@
 #include <sstream>
 
 namespace cbm {
-using namespace std;
 
 /*! \class MonitorSink
   \brief Monitor sink - abstract base class
@@ -27,7 +26,7 @@ using namespace std;
   \param path    path for output
  */
 
-MonitorSink::MonitorSink(Monitor& monitor, const string& path)
+MonitorSink::MonitorSink(Monitor& monitor, const std::string& path)
     : fMonitor(monitor), fSinkPath(path) {}
 
 //-----------------------------------------------------------------------------
@@ -40,11 +39,11 @@ MonitorSink::MonitorSink(Monitor& monitor, const string& path)
   should never contain them.
  */
 
-string MonitorSink::CleanString(const string& str) {
-  string res = str;
-  res.erase(remove(res.begin(), res.end(), ' '), res.end());
-  res.erase(remove(res.begin(), res.end(), '='), res.end());
-  res.erase(remove(res.begin(), res.end(), ','), res.end());
+std::string MonitorSink::CleanString(const std::string& str) {
+  std::string res = str;
+  res.erase(std::remove(res.begin(), res.end(), ' '), res.end());
+  res.erase(std::remove(res.begin(), res.end(), '='), res.end());
+  res.erase(std::remove(res.begin(), res.end(), ','), res.end());
   return res;
 }
 
@@ -54,10 +53,10 @@ string MonitorSink::CleanString(const string& str) {
   \returns string with all '"' characters escaped with a backslash
  */
 
-string MonitorSink::EscapeString(const string& str) {
-  string res = str;
+std::string MonitorSink::EscapeString(const std::string& str) {
+  std::string res = str;
   size_t pos = 0;
-  while ((pos = res.find('"', pos)) != string::npos) {
+  while ((pos = res.find('"', pos)) != std::string::npos) {
     res.replace(pos, 1, "\\\"");
     pos += 2;
   }
@@ -68,8 +67,8 @@ string MonitorSink::EscapeString(const string& str) {
 /*! \brief Return tagset string for a Metric `point` in InfluxDB line format
  */
 
-string MonitorSink::InfluxTags(const Metric& point) {
-  string res;
+std::string MonitorSink::InfluxTags(const Metric& point) {
+  std::string res;
   for (auto& tag : point.fTagset) {
     res += res.empty() ? "" : ",";
     res += CleanString(tag.first) + "=" + CleanString(tag.second);
@@ -84,8 +83,8 @@ string MonitorSink::InfluxTags(const Metric& point) {
 template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
-string MonitorSink::InfluxFields(const Metric& point) {
-  stringstream ss;
+std::string MonitorSink::InfluxFields(const Metric& point) {
+  std::stringstream ss;
   ss.precision(16); // ensure full double precision
   for (auto& field : point.fFieldset) {
     if (ss.tellp() != 0)
@@ -109,7 +108,7 @@ string MonitorSink::InfluxFields(const Metric& point) {
                      [&ss](double arg) { // case double
                        ss << arg;
                      },
-                     [this, &ss](const string& arg) { // case string
+                     [this, &ss](const std::string& arg) { // case string
                        ss << '"' << EscapeString(arg) << '"';
                      }},
           val);
@@ -121,14 +120,14 @@ string MonitorSink::InfluxFields(const Metric& point) {
 /*! \brief Return Metric `point` in InfluxDB line format
  */
 
-string MonitorSink::InfluxLine(const Metric& point) {
-  chrono::duration<long, std::nano> timestamp_ns =
-      point.fTimestamp - chrono::system_clock::time_point();
+std::string MonitorSink::InfluxLine(const Metric& point) {
+  std::chrono::duration<long, std::nano> timestamp_ns =
+      point.fTimestamp - std::chrono::system_clock::time_point();
 
-  string res = point.fMeasurement;
+  std::string res = point.fMeasurement;
   res += "," + InfluxTags(point);
   res += " " + InfluxFields(point);
-  res += " " + to_string(timestamp_ns.count());
+  res += " " + std::to_string(timestamp_ns.count());
   return res;
 }
 

--- a/lib/monitoring/MonitorSink.hpp
+++ b/lib/monitoring/MonitorSink.hpp
@@ -11,28 +11,27 @@
 #include <vector>
 
 namespace cbm {
-using namespace std;
 
 class Monitor; // forward declaration
 
 class MonitorSink {
 public:
-  MonitorSink(Monitor& monitor, const string& path);
+  MonitorSink(Monitor& monitor, const std::string& path);
   virtual ~MonitorSink() = default;
 
-  virtual void ProcessMetricVec(const vector<Metric>& metvec) = 0;
+  virtual void ProcessMetricVec(const std::vector<Metric>& metvec) = 0;
   virtual void ProcessHeartbeat() = 0;
 
 protected:
-  string CleanString(const string& id);
-  string EscapeString(const string& str);
-  string InfluxTags(const Metric& point);
-  string InfluxFields(const Metric& point);
-  string InfluxLine(const Metric& point);
+  std::string CleanString(const std::string& id);
+  std::string EscapeString(const std::string& str);
+  std::string InfluxTags(const Metric& point);
+  std::string InfluxFields(const Metric& point);
+  std::string InfluxLine(const Metric& point);
 
 protected:
   Monitor& fMonitor;       //!< back reference to Monitor
-  string fSinkPath;        //!< path for output
+  std::string fSinkPath;   //!< path for output
   long fStatNPoint{0};     //!< # of processed points
   long fStatNTag{0};       //!< # of processed tags
   long fStatNField{0};     //!< # of processed fields

--- a/lib/monitoring/MonitorSinkFile.cpp
+++ b/lib/monitoring/MonitorSinkFile.cpp
@@ -12,7 +12,7 @@
 #include <stdexcept>
 
 namespace cbm {
-using namespace std;
+using namespace std::string_literals; // for ""s
 
 /*! \class MonitorSinkFile
   \brief Monitor sink - concrete sink for file output
@@ -30,14 +30,14 @@ using namespace std;
   simultaneously and will receive the same data.
  */
 
-MonitorSinkFile::MonitorSinkFile(Monitor& monitor, const string& path)
+MonitorSinkFile::MonitorSinkFile(Monitor& monitor, const std::string& path)
     : MonitorSink(monitor, path) {
   if (path == "cout"s) {
-    fpCout = &cout;
+    fpCout = &std::cout;
   } else if (path == "cerr"s) {
-    fpCout = &cerr;
+    fpCout = &std::cerr;
   } else {
-    fpOStream = make_unique<ofstream>(path);
+    fpOStream = std::make_unique<std::ofstream>(path);
     if (!fpOStream->is_open())
       throw std::runtime_error(fmt::format("MonitorSinkFile::ctor: open()"
                                            " failed for '{}'",
@@ -49,8 +49,8 @@ MonitorSinkFile::MonitorSinkFile(Monitor& monitor, const string& path)
 /*! \brief Process a vector of metrics
  */
 
-void MonitorSinkFile::ProcessMetricVec(const vector<Metric>& metvec) {
-  ostream& os = fpCout ? *fpCout : *fpOStream;
+void MonitorSinkFile::ProcessMetricVec(const std::vector<Metric>& metvec) {
+  std::ostream& os = fpCout ? *fpCout : *fpOStream;
   for (auto& met : metvec)
     os << InfluxLine(met) << "\n";
   if (size(metvec) > 0)

--- a/lib/monitoring/MonitorSinkFile.hpp
+++ b/lib/monitoring/MonitorSinkFile.hpp
@@ -12,18 +12,17 @@
 #include <memory>
 
 namespace cbm {
-using namespace std;
 
 class MonitorSinkFile : public MonitorSink {
 public:
-  MonitorSinkFile(Monitor& monitor, const string& path);
+  MonitorSinkFile(Monitor& monitor, const std::string& path);
 
-  virtual void ProcessMetricVec(const vector<Metric>& metvec);
+  virtual void ProcessMetricVec(const std::vector<Metric>& metvec);
   virtual void ProcessHeartbeat();
 
 private:
-  ostream* fpCout{nullptr};         //!< pointer to cout/cerr
-  unique_ptr<ofstream> fpOStream{}; //!< uptr to general output stream
+  std::ostream* fpCout{nullptr};              //!< pointer to cout/cerr
+  std::unique_ptr<std::ofstream> fpOStream{}; //!< uptr to general output stream
 };
 
 } // end namespace cbm

--- a/lib/monitoring/MonitorSinkInflux1.hpp
+++ b/lib/monitoring/MonitorSinkInflux1.hpp
@@ -8,22 +8,21 @@
 #include "MonitorSink.hpp"
 
 namespace cbm {
-using namespace std;
 
 class MonitorSinkInflux1 : public MonitorSink {
 public:
-  MonitorSinkInflux1(Monitor& monitor, const string& path);
+  MonitorSinkInflux1(Monitor& monitor, const std::string& path);
 
-  virtual void ProcessMetricVec(const vector<Metric>& metvec);
+  virtual void ProcessMetricVec(const std::vector<Metric>& metvec);
   virtual void ProcessHeartbeat();
 
 private:
-  void SendData(const string& msg);
+  void SendData(const std::string& msg);
 
 private:
-  string fHost; //!< server host name
-  string fPort; //!< port for InfluxDB
-  string fDB;   //!< target database
+  std::string fHost; //!< server host name
+  std::string fPort; //!< port for InfluxDB
+  std::string fDB;   //!< target database
 };
 
 } // end namespace cbm

--- a/lib/monitoring/MonitorSinkInflux2.hpp
+++ b/lib/monitoring/MonitorSinkInflux2.hpp
@@ -8,23 +8,21 @@
 #include "MonitorSink.hpp"
 
 namespace cbm {
-using namespace std;
-
 class MonitorSinkInflux2 : public MonitorSink {
 public:
-  MonitorSinkInflux2(Monitor& monitor, const string& path);
+  MonitorSinkInflux2(Monitor& monitor, const std::string& path);
 
-  virtual void ProcessMetricVec(const vector<Metric>& metvec);
+  virtual void ProcessMetricVec(const std::vector<Metric>& metvec);
   virtual void ProcessHeartbeat();
 
 private:
-  void SendData(const string& msg);
+  void SendData(const std::string& msg);
 
 private:
-  string fHost;   //!< server host name
-  string fPort;   //!< port for InfluxDB
-  string fBucket; //!< target bucket
-  string fToken;  //!< access token
+  std::string fHost;   //!< server host name
+  std::string fPort;   //!< port for InfluxDB
+  std::string fBucket; //!< target bucket
+  std::string fToken;  //!< access token
 };
 
 } // end namespace cbm

--- a/lib/monitoring/System.cpp
+++ b/lib/monitoring/System.cpp
@@ -107,7 +107,7 @@ std::string current_thread_name() {
 #else
   return std::string();
 #endif
-};
+}
 
 void set_thread_name(const std::string& tname [[maybe_unused]]) {
 #if defined(HAVE_PTHREAD_SETNAME_NP)
@@ -122,7 +122,7 @@ void set_thread_name(const std::string& tname [[maybe_unused]]) {
     throw std::runtime_error(stringerror(errno));
   }
 #endif
-};
+}
 
 std::vector<std::string> glob(const std::string& pattern, glob_flags flags) {
   glob_t glob_result{};


### PR DESCRIPTION
The monitoring library was importing std into the cbm namespace. This PR removes this behaviour. Resolves #106.