### PR TITLE
Improvements to tsclient

### DIFF
--- a/app/tsclient/Application.cpp
+++ b/app/tsclient/Application.cpp
@@ -96,7 +96,15 @@ void Application::run() {
 
   uint64_t limit = par_.maximum_number();
 
+  uint64_t index = 0;
   while (auto timeslice = source_->get()) {
+    if (index >= par_.offset() &&
+        (index - par_.offset()) % par_.stride() == 0) {
+      ++index;
+    } else {
+      ++index;
+      continue;
+    }
     std::shared_ptr<const fles::Timeslice> ts(std::move(timeslice));
     if (par_.rate_limit() != 0.0) {
       rate_limit_delay();

--- a/app/tsclient/Application.cpp
+++ b/app/tsclient/Application.cpp
@@ -86,6 +86,20 @@ void Application::rate_limit_delay() const {
   }
 }
 
+void Application::native_speed_delay(uint64_t ts_start_time) {
+  if (count_ == 0) {
+    first_ts_start_time_ = ts_start_time;
+  } else {
+    auto delta_is = std::chrono::high_resolution_clock::now() - time_begin_;
+    auto delta_want =
+        std::chrono::nanoseconds(ts_start_time - first_ts_start_time_) /
+        par_.native_speed();
+    if (delta_want > delta_is) {
+      std::this_thread::sleep_for(delta_want - delta_is);
+    }
+  }
+}
+
 void Application::run() {
   time_begin_ = std::chrono::high_resolution_clock::now();
 
@@ -106,6 +120,9 @@ void Application::run() {
       continue;
     }
     std::shared_ptr<const fles::Timeslice> ts(std::move(timeslice));
+    if (par_.native_speed() != 0.0) {
+      native_speed_delay(ts->start_time());
+    }
     if (par_.rate_limit() != 0.0) {
       rate_limit_delay();
     }

--- a/app/tsclient/Application.hpp
+++ b/app/tsclient/Application.hpp
@@ -40,6 +40,8 @@ private:
   std::string output_prefix_;
 
   std::chrono::high_resolution_clock::time_point time_begin_;
+  uint64_t first_ts_start_time_;
 
   void rate_limit_delay() const;
+  void native_speed_delay(uint64_t ts_start_time);
 };

--- a/app/tsclient/Parameters.cpp
+++ b/app/tsclient/Parameters.cpp
@@ -74,6 +74,8 @@ void Parameters::parse_options(int argc, char* argv[]) {
            "(default: 1)");
   desc_add("rate-limit", po::value<double>(&rate_limit_),
            "limit the item rate to given frequency (in Hz)");
+  desc_add("speed", po::value<double>(&native_speed_),
+           "limit the item rate to given factor of original speed");
 
   po::variables_map vm;
   po::store(po::parse_command_line(argc, argv, desc), vm);

--- a/app/tsclient/Parameters.cpp
+++ b/app/tsclient/Parameters.cpp
@@ -66,6 +66,12 @@ void Parameters::parse_options(int argc, char* argv[]) {
   desc_add("maximum-number,n", po::value<uint64_t>(&maximum_number_),
            "set the maximum number of timeslices to process (default: "
            "unlimited)");
+  desc_add("offset", po::value<uint64_t>(&offset_),
+           "set the offset of timeslices to select for processing "
+           "(default: 0)");
+  desc_add("stride", po::value<uint64_t>(&stride_),
+           "set the stride of timeslices to select for processing "
+           "(default: 1)");
   desc_add("rate-limit", po::value<double>(&rate_limit_),
            "limit the item rate to given frequency (in Hz)");
 
@@ -99,5 +105,8 @@ void Parameters::parse_options(int argc, char* argv[]) {
   }
   if (input_sources > 1) {
     throw ParametersException("more than one input source specified");
+  }
+  if (stride_ == 0) {
+    throw ParametersException("stride must be greater than zero");
   }
 }

--- a/app/tsclient/Parameters.hpp
+++ b/app/tsclient/Parameters.hpp
@@ -56,6 +56,8 @@ public:
 
   [[nodiscard]] double rate_limit() const { return rate_limit_; }
 
+  [[nodiscard]] double native_speed() const { return native_speed_; }
+
 private:
   void parse_options(int argc, char* argv[]);
 
@@ -76,4 +78,5 @@ private:
   uint64_t offset_ = 0;
   uint64_t stride_ = 1;
   double rate_limit_ = 0.0;
+  double native_speed_ = 0.0;
 };

--- a/app/tsclient/Parameters.hpp
+++ b/app/tsclient/Parameters.hpp
@@ -50,6 +50,10 @@ public:
 
   [[nodiscard]] uint64_t maximum_number() const { return maximum_number_; }
 
+  [[nodiscard]] uint64_t offset() const { return offset_; }
+
+  [[nodiscard]] uint64_t stride() const { return stride_; }
+
   [[nodiscard]] double rate_limit() const { return rate_limit_; }
 
 private:
@@ -69,5 +73,7 @@ private:
   std::string publish_address_;
   uint32_t publish_hwm_ = 1;
   uint64_t maximum_number_ = UINT64_MAX;
+  uint64_t offset_ = 0;
+  uint64_t stride_ = 1;
   double rate_limit_ = 0.0;
 };

--- a/lib/fles_core/TimesliceAnalyzer.hpp
+++ b/lib/fles_core/TimesliceAnalyzer.hpp
@@ -58,6 +58,7 @@ private:
 
   crcutil_interface::CRC* crc32_engine_ = nullptr;
 
+  uint64_t start_index_ = 0;
   std::vector<fles::MicrosliceDescriptor> reference_descriptors_;
   std::vector<std::unique_ptr<PatternChecker>> pattern_checkers_;
 

--- a/lib/fles_ipc/TimesliceAutoSource.cpp
+++ b/lib/fles_ipc/TimesliceAutoSource.cpp
@@ -38,8 +38,7 @@ void TimesliceAutoSource::init(const std::vector<std::string>& locators) {
           cycles = stoull(value);
         } else {
           throw std::runtime_error(
-              "query parameter not implemented for scheme " + uri.scheme +
-              ": " + key);
+              "query parameter not implemented for scheme file: " + key);
         }
       }
       const auto file_path = uri.authority + uri.path;
@@ -49,7 +48,7 @@ void TimesliceAutoSource::init(const std::vector<std::string>& locators) {
       // The sequence number placeholder "%n" is expanded to the first valid
       // value of "0000" before glob'ing and replaced back afterwards. This
       // will not work if the pathname contains both the placeholder and the
-      // string "0000". Nonexistant files are catched already at this stage by
+      // string "0000". Nonexistant files are caught already at this stage by
       // glob() throwing a runtime_error.
       auto paths = system::glob(replace_all_copy(file_path, "%n", "0000"));
       if (file_path.find("%n") != std::string::npos) {


### PR DESCRIPTION
This PR includes three improvements to tsclient in preparation for the upcoming data challenge:

- The status output generated when specifying the `-a` option now includes information about the timeslice duration, start time, and start index.
- The `--offset` and `--stride` options allow us to skip timeslices when running, which can be used to split .tsa files
- The `--speed` option throttles the main loop to the original speed as seen from the start times of the timeslices. A factor othen than 1 can be used to speed the replay up or down.