### PR TITLE
ArchiveType: Add entry to store processing results.

### DIFF
--- a/lib/fles_ipc/ArchiveDescriptor.hpp
+++ b/lib/fles_ipc/ArchiveDescriptor.hpp
@@ -12,7 +12,11 @@
 namespace fles {
 
 /// The archive type enum (e.g., timeslice, microslice)
-enum class ArchiveType { TimesliceArchive, MicrosliceArchive };
+enum class ArchiveType {
+  TimesliceArchive,
+  MicrosliceArchive,
+  RecoResultsArchive
+};
 
 template <class Base, class Derived, ArchiveType archive_type>
 class InputArchive;


### PR DESCRIPTION
Adds an entry to `ArchiveType`  to store processing results.

This is a prerequisite to reuse fles-classes for reading / storing archives (`InputArchive`, `OutputArchive`) in CbmRoot Online code. 