### PR TITLE
Monitoring: Fix possible types of MetricField.

### DIFF
--- a/lib/monitoring/Metric.hpp
+++ b/lib/monitoring/Metric.hpp
@@ -6,15 +6,24 @@
 #define included_Cbm_Metric 1
 
 #include <chrono>
+#include <cstddef>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <variant>
 #include <vector>
 
 namespace cbm {
 using MetricTagSet = std::vector<std::pair<std::string, std::string>>;
-using MetricField =
-    std::variant<bool, int, long, unsigned long, double, std::string>;
+using MetricField = std::variant<bool,
+                                 int32_t,
+                                 uint32_t,
+                                 int64_t,
+                                 uint64_t,
+                                 float,
+                                 double,
+                                 std::string,
+                                 std::string_view>;
 using MetricFieldSet = std::vector<std::pair<std::string, MetricField>>;
 
 struct Metric {

--- a/lib/monitoring/MonitorSink.hpp
+++ b/lib/monitoring/MonitorSink.hpp
@@ -8,6 +8,7 @@
 #include "Metric.hpp"
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace cbm {
@@ -24,7 +25,7 @@ public:
 
 protected:
   std::string CleanString(const std::string& id);
-  std::string EscapeString(const std::string& str);
+  std::string EscapeString(std::string_view str);
   std::string InfluxTags(const Metric& point);
   std::string InfluxFields(const Metric& point);
   std::string InfluxLine(const Metric& point);


### PR DESCRIPTION
During DC July23, we discovered the `MetricField` definition causes some problems on older versions of Mac OS due to confusions between `long` and `long long` types. 

This MR provides a fix by replacing the integer types with fixed size integers. Additionally I took the liberty to add some more types to `MetricField` that could be useful.