### PR TITLE
Shared memory timeslice output for tsclient

### DIFF
--- a/app/tsclient/Application.hpp
+++ b/app/tsclient/Application.hpp
@@ -8,13 +8,15 @@
 #include "TimesliceSource.hpp"
 #include "log.hpp"
 #include <chrono>
+#include <csignal>
 #include <memory>
 #include <vector>
+#include <zmq.hpp>
 
 /// %Application base class.
 class Application {
 public:
-  explicit Application(Parameters const& par);
+  Application(Parameters const& par, volatile sig_atomic_t* signal_status);
 
   Application(const Application&) = delete;
   void operator=(const Application&) = delete;
@@ -25,9 +27,13 @@ public:
 
 private:
   Parameters const& par_;
+  volatile sig_atomic_t* signal_status_;
 
   /// The application's monitoring object
   std::unique_ptr<cbm::Monitor> monitor_;
+
+  /// The application's ZeroMQ context
+  zmq::context_t zmq_context_{1};
 
   std::unique_ptr<fles::TimesliceSource> source_;
   std::vector<std::unique_ptr<fles::TimesliceSink>> sinks_;

--- a/app/tsclient/Application.hpp
+++ b/app/tsclient/Application.hpp
@@ -40,7 +40,7 @@ private:
   std::string output_prefix_;
 
   std::chrono::high_resolution_clock::time_point time_begin_;
-  uint64_t first_ts_start_time_;
+  uint64_t first_ts_start_time_{};
 
   void rate_limit_delay() const;
   void native_speed_delay(uint64_t ts_start_time);

--- a/app/tsclient/Parameters.cpp
+++ b/app/tsclient/Parameters.cpp
@@ -112,7 +112,9 @@ void Parameters::parse_options(int argc, char* argv[]) {
                         static_cast<severity_level>(log_syslog));
   }
 
-  output_uris_ = vm["output-uri"].as<std::vector<std::string>>();
+  if (vm.count("output-uri") != 0u) {
+    output_uris_ = vm["output-uri"].as<std::vector<std::string>>();
+  }
 
   size_t input_sources = vm.count("input-uri");
   if (input_sources == 0 && !benchmark_) {

--- a/app/tsclient/Parameters.hpp
+++ b/app/tsclient/Parameters.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 /// Run parameter exception class.
 class ParametersException : public std::runtime_error {
@@ -26,14 +27,8 @@ public:
 
   [[nodiscard]] std::string input_uri() const { return input_uri_; }
 
-  [[nodiscard]] std::string output_archive() const { return output_archive_; }
-
-  [[nodiscard]] size_t output_archive_items() const {
-    return output_archive_items_;
-  }
-
-  [[nodiscard]] size_t output_archive_bytes() const {
-    return output_archive_bytes_;
+  [[nodiscard]] std::vector<std::string> output_uris() const {
+    return output_uris_;
   }
 
   [[nodiscard]] bool analyze() const { return analyze_; }
@@ -43,10 +38,6 @@ public:
   [[nodiscard]] size_t verbosity() const { return verbosity_; }
 
   [[nodiscard]] bool histograms() const { return histograms_; }
-
-  [[nodiscard]] std::string publish_address() const { return publish_address_; }
-
-  [[nodiscard]] uint32_t publish_hwm() const { return publish_hwm_; }
 
   [[nodiscard]] uint64_t maximum_number() const { return maximum_number_; }
 
@@ -65,15 +56,11 @@ private:
 
   int32_t client_index_ = -1;
   std::string input_uri_;
-  std::string output_archive_;
-  size_t output_archive_items_ = SIZE_MAX;
-  size_t output_archive_bytes_ = SIZE_MAX;
+  std::vector<std::string> output_uris_;
   bool analyze_ = false;
   bool benchmark_ = false;
   size_t verbosity_ = 0;
   bool histograms_ = false;
-  std::string publish_address_;
-  uint32_t publish_hwm_ = 1;
   uint64_t maximum_number_ = UINT64_MAX;
   uint64_t offset_ = 0;
   uint64_t stride_ = 1;

--- a/app/tsclient/main.cpp
+++ b/app/tsclient/main.cpp
@@ -3,11 +3,21 @@
 #include "Application.hpp"
 #include "Parameters.hpp"
 #include "log.hpp"
+#include <csignal>
+
+namespace {
+volatile sig_atomic_t signal_status = 0;
+}
+
+static void signal_handler(int sig) { signal_status = sig; }
 
 int main(int argc, char* argv[]) {
+  std::signal(SIGINT, signal_handler);
+  std::signal(SIGTERM, signal_handler);
+
   try {
     Parameters par(argc, argv);
-    Application app(par);
+    Application app(par, &signal_status);
     app.run();
   } catch (std::exception const& e) {
     L_(fatal) << e.what();

--- a/doc/structure.txt
+++ b/doc/structure.txt
@@ -1,0 +1,25 @@
+Structure of the project
+========================
+
+The project is divided into several libraries:
+
+Libraries with no internal dependencies (leaves)
+------------------------------------------------
+
+- crcutil
+- cri
+- logging
+- monitoring
+- pda
+
+Libraries with internal dependencies
+------------------------------------
+
+- logging
+  -> shm_ipc
+    -> fles_ipc
+      -> fles_core (with crcutil, monitoring)
+        -> fles_libfabric
+        -> fles_rdma
+        -> fles_zeromq
+        -> flib_ipc

--- a/lib/cri/CMakeLists.txt
+++ b/lib/cri/CMakeLists.txt
@@ -18,7 +18,7 @@ set(LIB_HDR
   cri_registers.hpp
 )
 
-Add_library(cri STATIC ${LIB_HDR} ${LIB_SRC})
+add_library(cri STATIC ${LIB_HDR} ${LIB_SRC})
 
 set_target_properties(cri PROPERTIES OUTPUT_NAME cri)
 

--- a/lib/fles_core/ManagedTimesliceBuffer.cpp
+++ b/lib/fles_core/ManagedTimesliceBuffer.cpp
@@ -1,0 +1,98 @@
+// Copyright 2023 Jan de Cuveland <cmail@cuveland.de>
+
+#include "ManagedTimesliceBuffer.hpp"
+#include "Timeslice.hpp"
+#include "TimesliceWorkItem.hpp"
+#include <chrono>
+#include <thread>
+
+ManagedTimesliceBuffer::ManagedTimesliceBuffer(
+    zmq::context_t& context,
+    const std::string& distributor_address,
+    const std::string& shm_identifier,
+    uint32_t data_buffer_size_exp,
+    uint32_t desc_buffer_size_exp,
+    uint32_t num_input_nodes)
+    : timeslice_buffer_(context,
+                        distributor_address,
+                        shm_identifier,
+                        data_buffer_size_exp,
+                        desc_buffer_size_exp,
+                        num_input_nodes) {
+
+  for (uint_fast16_t i = 0; i < num_input_nodes; ++i) {
+    desc_.emplace_back(timeslice_buffer_.get_desc_ptr(i),
+                       timeslice_buffer_.get_desc_size_exp());
+    data_.emplace_back(timeslice_buffer_.get_data_ptr(i),
+                       timeslice_buffer_.get_data_size_exp());
+  }
+}
+
+void ManagedTimesliceBuffer::handle_timeslice_completions() {
+  fles::TimesliceCompletion c{};
+  while (timeslice_buffer_.try_receive_completion(c)) {
+    if (c.ts_pos == acked_) {
+      do {
+        ++acked_;
+      } while (ack_.at(acked_) > c.ts_pos);
+      for (uint_fast16_t i = 0; i < desc_.size(); ++i) {
+        desc_.at(i).set_read_index(acked_);
+        data_.at(i).set_read_index(desc_.at(i).at(acked_ - 1).offset +
+                                   desc_.at(i).at(acked_ - 1).size);
+      }
+    } else {
+      ack_.at(c.ts_pos) = c.ts_pos;
+    }
+  }
+}
+
+bool ManagedTimesliceBuffer::timeslice_fits_in_buffer(
+    const fles::Timeslice& timeslice) {
+  for (uint_fast16_t i = 0; i < timeslice.num_components(); ++i) {
+    if (data_.at(i).size_available_contiguous() < timeslice.size_component(i) ||
+        desc_.at(i).size_available() < 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void ManagedTimesliceBuffer::put(
+    std::shared_ptr<const fles::Timeslice> timeslice) {
+
+  // The existing shared memory TimesliceBuffer has to support the correct
+  // number of input nodes.
+  if (timeslice->num_components() != timeslice_buffer_.get_num_input_nodes()) {
+    throw std::runtime_error("Timeslice has wrong number of components");
+  }
+
+  // Poll for timeslice completions until enough space is available.
+  handle_timeslice_completions();
+  while (!timeslice_fits_in_buffer(*timeslice)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    handle_timeslice_completions();
+  }
+
+  // Copy each component to the shared memory buffer.
+  for (uint_fast16_t i = 0; i < timeslice->num_components(); ++i) {
+
+    // Skip remaining bytes in the data buffer to avoid a fragmented entry.
+    data_.at(i).skip_buffer_wrap(timeslice->size_component(i));
+
+    // Rewrite the offset in the timeslice component descriptor.
+    auto tscd = timeslice->desc_ptr_[i];
+    tscd->offset = data_.at(i).write_index();
+
+    // Copy the data into the shared memory.
+    data_.at(i).append(timeslice->data_ptr_[i], timeslice->size_component(i));
+    desc_.at(i).append(tscd, 1);
+  }
+
+  // Rewrite the timeslice index in the descriptor
+  auto tsd = timeslice->timeslice_descriptor_;
+  tsd.ts_pos = ts_pos_++;
+
+  // Send the work item.
+  timeslice_buffer_.send_work_item({tsd, timeslice_buffer_.get_data_size_exp(),
+                                    timeslice_buffer_.get_desc_size_exp()});
+}

--- a/lib/fles_core/ManagedTimesliceBuffer.cpp
+++ b/lib/fles_core/ManagedTimesliceBuffer.cpp
@@ -4,28 +4,35 @@
 #include "Timeslice.hpp"
 #include "TimesliceWorkItem.hpp"
 #include <chrono>
-#include <thread>
 
 ManagedTimesliceBuffer::ManagedTimesliceBuffer(
     zmq::context_t& context,
-    const std::string& distributor_address,
     const std::string& shm_identifier,
     uint32_t data_buffer_size_exp,
     uint32_t desc_buffer_size_exp,
     uint32_t num_input_nodes)
-    : timeslice_buffer_(context,
-                        distributor_address,
+    : producer_address_("inproc://" + shm_identifier),
+      worker_address_("ipc://@" + shm_identifier),
+      item_distributor_(context, producer_address_, worker_address_),
+      timeslice_buffer_(context,
+                        producer_address_,
                         shm_identifier,
                         data_buffer_size_exp,
                         desc_buffer_size_exp,
-                        num_input_nodes) {
-
-  for (uint_fast16_t i = 0; i < num_input_nodes; ++i) {
+                        num_input_nodes),
+      ack_(desc_buffer_size_exp),
+      distributor_thread_(std::ref(item_distributor_)) {
+  for (uint32_t i = 0; i < num_input_nodes; ++i) {
     desc_.emplace_back(timeslice_buffer_.get_desc_ptr(i),
                        timeslice_buffer_.get_desc_size_exp());
     data_.emplace_back(timeslice_buffer_.get_data_ptr(i),
                        timeslice_buffer_.get_data_size_exp());
   }
+}
+
+ManagedTimesliceBuffer::~ManagedTimesliceBuffer() {
+  item_distributor_.stop();
+  distributor_thread_.join();
 }
 
 void ManagedTimesliceBuffer::handle_timeslice_completions() {
@@ -35,7 +42,7 @@ void ManagedTimesliceBuffer::handle_timeslice_completions() {
       do {
         ++acked_;
       } while (ack_.at(acked_) > c.ts_pos);
-      for (uint_fast16_t i = 0; i < desc_.size(); ++i) {
+      for (std::size_t i = 0; i < desc_.size(); ++i) {
         desc_.at(i).set_read_index(acked_);
         data_.at(i).set_read_index(desc_.at(i).at(acked_ - 1).offset +
                                    desc_.at(i).at(acked_ - 1).size);
@@ -48,7 +55,7 @@ void ManagedTimesliceBuffer::handle_timeslice_completions() {
 
 bool ManagedTimesliceBuffer::timeslice_fits_in_buffer(
     const fles::Timeslice& timeslice) {
-  for (uint_fast16_t i = 0; i < timeslice.num_components(); ++i) {
+  for (uint64_t i = 0; i < timeslice.num_components(); ++i) {
     if (data_.at(i).size_available_contiguous() < timeslice.size_component(i) ||
         desc_.at(i).size_available() < 1) {
       return false;
@@ -65,7 +72,6 @@ void ManagedTimesliceBuffer::put(
   if (timeslice->num_components() != timeslice_buffer_.get_num_input_nodes()) {
     throw std::runtime_error("Timeslice has wrong number of components");
   }
-
   // Poll for timeslice completions until enough space is available.
   handle_timeslice_completions();
   while (!timeslice_fits_in_buffer(*timeslice)) {
@@ -74,7 +80,7 @@ void ManagedTimesliceBuffer::put(
   }
 
   // Copy each component to the shared memory buffer.
-  for (uint_fast16_t i = 0; i < timeslice->num_components(); ++i) {
+  for (uint64_t i = 0; i < timeslice->num_components(); ++i) {
 
     // Skip remaining bytes in the data buffer to avoid a fragmented entry.
     data_.at(i).skip_buffer_wrap(timeslice->size_component(i));

--- a/lib/fles_core/ManagedTimesliceBuffer.hpp
+++ b/lib/fles_core/ManagedTimesliceBuffer.hpp
@@ -33,6 +33,12 @@ public:
 
   void put(std::shared_ptr<const fles::Timeslice> timeslice) override;
 
+  /// Return true if the buffer is empty.
+  [[nodiscard]] bool empty() const { return acked_ == ts_pos_; }
+
+  /// Handle pending timeslice completions and advance read indexes.
+  void handle_timeslice_completions();
+
 private:
   /// Address that is used for communication between the TimesliceBuffer and the
   /// ItemDistributor.
@@ -63,9 +69,6 @@ private:
   /// ManagedRingBuffer wrappers for the TimesliceComponentDescriptor buffer.
   std::vector<ManagedRingBuffer<fles::TimesliceComponentDescriptor>> desc_;
   std::vector<ManagedRingBuffer<uint8_t>> data_;
-
-  /// Handle pending timeslice completions and advance read indexes.
-  void handle_timeslice_completions();
 
   /// Check if the timeslice fits in the buffer.
   bool timeslice_fits_in_buffer(const fles::Timeslice& timeslice);

--- a/lib/fles_core/ManagedTimesliceBuffer.hpp
+++ b/lib/fles_core/ManagedTimesliceBuffer.hpp
@@ -1,11 +1,13 @@
 // Copyright 2023 Jan de Cuveland <cmail@cuveland.de>
 #pragma once
 
+#include "ItemDistributor.hpp"
 #include "ManagedRingBuffer.hpp"
 #include "RingBuffer.hpp"
 #include "Sink.hpp"
 #include "TimesliceBuffer.hpp"
 #include "TimesliceComponentDescriptor.hpp"
+#include <thread>
 #include <vector>
 #include <zmq.h>
 
@@ -18,11 +20,13 @@ class ManagedTimesliceBuffer : public fles::TimesliceSink {
 public:
   /// The ManagedTimesliceBuffer constructor.
   ManagedTimesliceBuffer(zmq::context_t& context,
-                         const std::string& distributor_address,
                          const std::string& shm_identifier,
                          uint32_t data_buffer_size_exp,
                          uint32_t desc_buffer_size_exp,
                          uint32_t num_input_nodes);
+
+  /// The ManagedTimesliceBuffer destructor.
+  ~ManagedTimesliceBuffer() override;
 
   ManagedTimesliceBuffer(const ManagedTimesliceBuffer&) = delete;
   void operator=(const ManagedTimesliceBuffer&) = delete;
@@ -30,8 +34,24 @@ public:
   void put(std::shared_ptr<const fles::Timeslice> timeslice) override;
 
 private:
+  /// Address that is used for communication between the TimesliceBuffer and the
+  /// ItemDistributor.
+  const std::string producer_address_;
+
+  /// Address that is used by Workers to connect to the ItemDistributor.
+  const std::string worker_address_;
+
+  /// The ItemDistributor object.
+  ItemDistributor item_distributor_;
+
   /// Shared memory buffer to store received timeslices.
   TimesliceBuffer timeslice_buffer_;
+
+  /// Buffer to store acknowledged status of timeslices.
+  RingBuffer<uint64_t, true> ack_;
+
+  /// Thread for the ItemDistributor.
+  std::thread distributor_thread_;
 
   /// The index of acknowledged timeslices (local buffer position).
   uint64_t acked_ = 0;
@@ -39,9 +59,6 @@ private:
   /// The index of the timeslice currently being received (local buffer
   /// position).
   uint64_t ts_pos_ = 0;
-
-  /// Buffer to store acknowledged status of timeslices.
-  RingBuffer<uint64_t, true> ack_;
 
   /// ManagedRingBuffer wrappers for the TimesliceComponentDescriptor buffer.
   std::vector<ManagedRingBuffer<fles::TimesliceComponentDescriptor>> desc_;

--- a/lib/fles_core/ManagedTimesliceBuffer.hpp
+++ b/lib/fles_core/ManagedTimesliceBuffer.hpp
@@ -1,0 +1,55 @@
+// Copyright 2023 Jan de Cuveland <cmail@cuveland.de>
+#pragma once
+
+#include "ManagedRingBuffer.hpp"
+#include "RingBuffer.hpp"
+#include "Sink.hpp"
+#include "TimesliceBuffer.hpp"
+#include "TimesliceComponentDescriptor.hpp"
+#include <vector>
+#include <zmq.h>
+
+/**
+ * \brief The ManagedTimesliceBuffer manages the items in a shared memory
+ * TimesliceBuffer. It implements the TimesliceSink interface to receive
+ * Timeslice objects.
+ */
+class ManagedTimesliceBuffer : public fles::TimesliceSink {
+public:
+  /// The ManagedTimesliceBuffer constructor.
+  ManagedTimesliceBuffer(zmq::context_t& context,
+                         const std::string& distributor_address,
+                         const std::string& shm_identifier,
+                         uint32_t data_buffer_size_exp,
+                         uint32_t desc_buffer_size_exp,
+                         uint32_t num_input_nodes);
+
+  ManagedTimesliceBuffer(const ManagedTimesliceBuffer&) = delete;
+  void operator=(const ManagedTimesliceBuffer&) = delete;
+
+  void put(std::shared_ptr<const fles::Timeslice> timeslice) override;
+
+private:
+  /// Shared memory buffer to store received timeslices.
+  TimesliceBuffer timeslice_buffer_;
+
+  /// The index of acknowledged timeslices (local buffer position).
+  uint64_t acked_ = 0;
+
+  /// The index of the timeslice currently being received (local buffer
+  /// position).
+  uint64_t ts_pos_ = 0;
+
+  /// Buffer to store acknowledged status of timeslices.
+  RingBuffer<uint64_t, true> ack_;
+
+  /// ManagedRingBuffer wrappers for the TimesliceComponentDescriptor buffer.
+  std::vector<ManagedRingBuffer<fles::TimesliceComponentDescriptor>> desc_;
+  std::vector<ManagedRingBuffer<uint8_t>> data_;
+
+  /// Handle pending timeslice completions and advance read indexes.
+  void handle_timeslice_completions();
+
+  /// Check if the timeslice fits in the buffer.
+  bool timeslice_fits_in_buffer(const fles::Timeslice& timeslice);
+};

--- a/lib/fles_core/TimesliceBuffer.hpp
+++ b/lib/fles_core/TimesliceBuffer.hpp
@@ -40,39 +40,54 @@ public:
   /// The TimesliceBuffer destructor.
   ~TimesliceBuffer();
 
+  /// Get the 2's exponent of the size of the data buffer per input node in
+  /// bytes.
   [[nodiscard]] uint32_t get_data_size_exp() const {
     return data_buffer_size_exp_;
   }
+
+  /// Get the 2's exponent of the size of the descriptor buffer per input node
+  /// in units of TimesliceComponentDescriptors.
   [[nodiscard]] uint32_t get_desc_size_exp() const {
     return desc_buffer_size_exp_;
   }
 
-  uint8_t* get_data_ptr(uint_fast16_t index) {
+  /// Get the pointer to the data buffer of the specified input node.
+  [[nodiscard]] uint8_t* get_data_ptr(uint_fast16_t index) const {
     return data_ptr_ + index * (UINT64_C(1) << data_buffer_size_exp_);
   }
 
-  fles::TimesliceComponentDescriptor* get_desc_ptr(uint_fast16_t index) {
+  /// Get the pointer to the descriptor buffer of the specified input node.
+  [[nodiscard]] fles::TimesliceComponentDescriptor*
+  get_desc_ptr(uint_fast16_t index) {
     return desc_ptr_ + index * (UINT64_C(1) << desc_buffer_size_exp_);
   }
 
-  uint8_t& get_data(uint_fast16_t index, uint64_t offset) {
+  /// Get the reference to the data buffer of the specified input node at the
+  /// given offset.
+  [[nodiscard]] uint8_t& get_data(uint_fast16_t index, uint64_t offset) {
     offset &= (UINT64_C(1) << data_buffer_size_exp_) - 1;
     return get_data_ptr(index)[offset];
   }
 
-  fles::TimesliceComponentDescriptor& get_desc(uint_fast16_t index,
-                                               uint64_t offset) {
+  /// Get the reference to the descriptor buffer of the specified input node at
+  /// the given offset.
+  [[nodiscard]] fles::TimesliceComponentDescriptor&
+  get_desc(uint_fast16_t index, uint64_t offset) {
     offset &= (UINT64_C(1) << desc_buffer_size_exp_) - 1;
     return get_desc_ptr(index)[offset];
   }
 
+  /// Get the number of input nodes.
   [[nodiscard]] uint32_t get_num_input_nodes() const {
     return num_input_nodes_;
   }
 
+  /// Send a work item to the item distributor.
   void send_work_item(fles::TimesliceWorkItem wi);
 
-  bool try_receive_completion(fles::TimesliceCompletion& c) {
+  /// Receive a completion from the item distributor.
+  [[nodiscard]] bool try_receive_completion(fles::TimesliceCompletion& c) {
     ItemID id;
     if (!ItemProducer::try_receive_completion(&id)) {
       return false;
@@ -86,14 +101,15 @@ public:
 
   // Remaining member functions are for backwards compatibility only
 
-  void send_completion(fles::TimesliceCompletion /* c */) {
+  [[deprecated]] void send_completion(fles::TimesliceCompletion /* c */) {
     throw std::runtime_error(
         "TimesliceBuffer::send_completion() not supported");
   }
 
-  void send_end_work_item() {}
+  // Deprecated. Do not use.
+  [[deprecated]] void send_end_work_item() {}
 
-  void send_end_completion() {}
+  [[deprecated]] void send_end_completion() {}
 
   [[nodiscard]] std::size_t get_num_work_items() const {
     return outstanding_.size();
@@ -104,14 +120,18 @@ public:
   [[nodiscard]] std::string description() const;
 
 private:
-  std::string shm_identifier_;
-  boost::uuids::uuid shm_uuid_{};
-  uint32_t data_buffer_size_exp_;
-  uint32_t desc_buffer_size_exp_;
-  uint32_t num_input_nodes_;
+  std::string shm_identifier_;    ///< shared memory identifier
+  boost::uuids::uuid shm_uuid_{}; ///< shared memory UUID
+  uint32_t data_buffer_size_exp_; ///< 2's exponent of data buffer size in bytes
+  uint32_t desc_buffer_size_exp_; ///< 2's exponent of descriptor buffer size
+                                  ///< in units of TimesliceComponentDescriptors
+  uint32_t num_input_nodes_;      // number of input nodes
 
-  std::unique_ptr<boost::interprocess::managed_shared_memory> managed_shm_;
-  uint8_t* data_ptr_;
-  fles::TimesliceComponentDescriptor* desc_ptr_;
-  std::set<ItemID> outstanding_;
+  std::unique_ptr<boost::interprocess::managed_shared_memory>
+      managed_shm_;   ///< shared memory object
+  uint8_t* data_ptr_; ///< pointer to data buffer within shared memory
+  fles::TimesliceComponentDescriptor*
+      desc_ptr_;                 ///< pointer to descriptor
+                                 ///< buffer within shared memory
+  std::set<ItemID> outstanding_; ///< set of outstanding work items
 };

--- a/lib/fles_ipc/Timeslice.hpp
+++ b/lib/fles_ipc/Timeslice.hpp
@@ -15,6 +15,8 @@
 // reasons to avoid segfault similar to
 // http://lists.debian.org/debian-hppa/2009/11/msg00069.html
 
+class ManagedTimesliceBuffer;
+
 namespace fles {
 
 /**
@@ -98,6 +100,7 @@ protected:
   Timeslice() = default;
 
   friend class StorableTimeslice;
+  friend class ::ManagedTimesliceBuffer;
 
   /// The timeslice descriptor.
   TimesliceDescriptor timeslice_descriptor_{};

--- a/lib/fles_ipc/TimesliceAutoSource.cpp
+++ b/lib/fles_ipc/TimesliceAutoSource.cpp
@@ -94,7 +94,7 @@ void TimesliceAutoSource::init(const std::vector<std::string>& locators) {
       sources.emplace_back(std::move(source));
 
     } else if (uri.scheme == "shm") {
-      WorkerParameters param{1, 0, WorkerQueuePolicy::QueueAll,
+      WorkerParameters param{1, 0, WorkerQueuePolicy::QueueAll, 0,
                              "TimesliceAutoSource at PID " +
                                  std::to_string(system::current_pid())};
       for (auto& [key, value] : uri.query_components) {
@@ -108,6 +108,8 @@ void TimesliceAutoSource::init(const std::vector<std::string>& locators) {
               {"one", WorkerQueuePolicy::PrebufferOne},
               {"skip", WorkerQueuePolicy::Skip}};
           param.queue_policy = queue_map.at(value);
+        } else if (key == "group") {
+          param.group_id = std::stoull(value);
         } else {
           throw std::runtime_error(
               "query parameter not implemented for scheme " + uri.scheme +

--- a/lib/fles_ipc/TimesliceComponentDescriptor.hpp
+++ b/lib/fles_ipc/TimesliceComponentDescriptor.hpp
@@ -14,10 +14,21 @@ namespace fles {
  * \brief %Timeslice component descriptor struct.
  */
 struct TimesliceComponentDescriptor {
-  uint64_t ts_num;          ///< Timeslice index.
-  uint64_t offset;          ///< Start offset (in bytes) of corresponding data.
-  uint64_t size;            ///< Size (in bytes) of corresponding data.
-  uint64_t num_microslices; ///< Number of microslices.
+  /// Global index of the corresponding timeslice. Note: this
+  /// is not the same as the local index in the ring buffer.
+  uint64_t ts_num;
+
+  /// Start offset (in bytes) of the corresponding data
+  /// (microslice descriptors followed by microslice contents)
+  /// in the local data stream or ring buffer.
+  uint64_t offset;
+
+  /// Size (in bytes) of the corresponding data (microslice
+  /// descriptors followed by microslice contents).
+  uint64_t size;
+
+  /// Number of microslices.
+  uint64_t num_microslices;
 
   friend class boost::serialization::access;
   /// Provide boost serialization access.

--- a/lib/fles_ipc/TimesliceDescriptor.hpp
+++ b/lib/fles_ipc/TimesliceDescriptor.hpp
@@ -6,6 +6,7 @@
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/version.hpp>
 #include <cstdint>
+#include <ostream>
 
 namespace fles {
 
@@ -15,12 +16,18 @@ namespace fles {
  * \brief %Timeslice descriptor struct.
  */
 struct TimesliceDescriptor {
-  /// Global index of this timeslice
+  /// Global index of the timeslice. Monotonically increasing during a run,
+  /// relates to the timestamps of the data contents. Note: this is not the same
+  /// as the local index in the ring buffer.
   uint64_t index;
-  /// Start offset (in items) of this timeslice
+
+  /// Start offset (in items) of the timeslice in the local data stream or ring
+  /// buffer.
   uint64_t ts_pos;
+
   /// Number of core microslices
   uint32_t num_core_microslices;
+
   /// Number of components (contributing input channels)
   uint32_t num_components;
 

--- a/lib/fles_ipc/TimesliceReceiver.cpp
+++ b/lib/fles_ipc/TimesliceReceiver.cpp
@@ -21,9 +21,7 @@ TimesliceView* TimesliceReceiver::do_get() {
     return nullptr;
   }
 
-  while (true) {
-    auto item = worker_.get();
-
+  while (auto item = worker_.get()) {
     fles::TimesliceShmWorkItem timeslice_item;
     std::istringstream istream(item->payload());
     {
@@ -51,6 +49,9 @@ TimesliceView* TimesliceReceiver::do_get() {
 
     return new TimesliceView(managed_shm_, item, timeslice_item);
   }
+
+  eos_ = true;
+  return nullptr;
 }
 
 boost::uuids::uuid TimesliceReceiver::managed_shm_uuid() const {

--- a/lib/fles_zeromq/TimesliceBuilderZeromq.cpp
+++ b/lib/fles_zeromq/TimesliceBuilderZeromq.cpp
@@ -126,7 +126,7 @@ bool TimesliceBuilderZeromq::run_cycle() {
     handle_timeslice_completions();
   }
 
-  // skip remaining bytes in data buffer to avoid fractured entry
+  // skip remaining bytes in data buffer to avoid fragmented entry
   c->data.skip_buffer_wrap(size_required);
 
   // generate timeslice component descriptor

--- a/lib/monitoring/MonitorSink.cpp
+++ b/lib/monitoring/MonitorSink.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <iomanip>
 #include <sstream>
+#include <utility>
 
 namespace cbm {
 
@@ -26,8 +27,8 @@ namespace cbm {
   \param path    path for output
  */
 
-MonitorSink::MonitorSink(Monitor& monitor, const std::string& path)
-    : fMonitor(monitor), fSinkPath(path) {}
+MonitorSink::MonitorSink(Monitor& monitor, std::string path)
+    : fMonitor(monitor), fSinkPath(std::move(path)) {}
 
 //-----------------------------------------------------------------------------
 /*! \brief Removes protocol characters from a string

--- a/lib/monitoring/MonitorSink.hpp
+++ b/lib/monitoring/MonitorSink.hpp
@@ -17,7 +17,7 @@ class Monitor; // forward declaration
 
 class MonitorSink {
 public:
-  MonitorSink(Monitor& monitor, const std::string& path);
+  MonitorSink(Monitor& monitor, std::string path);
   virtual ~MonitorSink() = default;
 
   virtual void ProcessMetricVec(const std::vector<Metric>& metvec) = 0;

--- a/lib/monitoring/MonitorSinkInflux2.cpp
+++ b/lib/monitoring/MonitorSinkInflux2.cpp
@@ -20,10 +20,9 @@
 #include <boost/beast/http.hpp>
 #include <boost/beast/version.hpp>
 
+#include <cstdlib>
 #include <iostream>
 #include <regex>
-
-#include <stdlib.h>
 
 namespace cbm {
 using tcp = boost::asio::ip::tcp;     // from <boost/asio/ip/tcp.hpp>

--- a/lib/shm_ipc/ItemDistributorWorker.hpp
+++ b/lib/shm_ipc/ItemDistributorWorker.hpp
@@ -24,6 +24,8 @@ public:
 
   [[nodiscard]] WorkerQueuePolicy queue_policy() const { return queue_policy_; }
 
+  [[nodiscard]] size_t group_id() const { return group_id_; }
+
   [[nodiscard]] bool queue_empty() const { return waiting_items_.empty(); }
 
   void clear_queue() { waiting_items_.clear(); }
@@ -39,6 +41,15 @@ public:
     std::shared_ptr<Item> item = waiting_items_.front();
     waiting_items_.pop_front();
     return item;
+  }
+
+  void delete_from_queue(ItemID id) {
+    auto it = std::find_if(
+        std::begin(waiting_items_), std::end(waiting_items_),
+        [id](const std::shared_ptr<Item>& i) { return i->id() == id; });
+    if (it != std::end(waiting_items_)) {
+      waiting_items_.erase(it);
+    }
   }
 
   [[nodiscard]] bool is_idle() const { return outstanding_items_.empty(); }

--- a/lib/shm_ipc/ItemDistributorWorker.hpp
+++ b/lib/shm_ipc/ItemDistributorWorker.hpp
@@ -72,7 +72,8 @@ public:
 
   [[nodiscard]] std::string description() const {
     return client_name_ + " (s" + std::to_string(stride_) + "/o" +
-           std::to_string(offset_) + "/p" + to_string(queue_policy_) + ")";
+           std::to_string(offset_) + "/p" + to_string(queue_policy_) + "/g" +
+           std::to_string(group_id_) + ")";
   }
 
 private:
@@ -80,7 +81,8 @@ private:
     std::string command;
     std::stringstream s(message);
     // Read space-separated string into separate variables
-    s >> command >> stride_ >> offset_ >> queue_policy_ >> client_name_;
+    s >> command >> stride_ >> offset_ >> queue_policy_ >> group_id_ >>
+        client_name_;
     // Read remainder of string and add contents to client_name_
     client_name_ += std::string(std::istreambuf_iterator<char>(s), {});
     if (s.fail()) {
@@ -91,6 +93,7 @@ private:
   size_t stride_{};
   size_t offset_{};
   WorkerQueuePolicy queue_policy_{};
+  size_t group_id_{};
   std::string client_name_;
 
   std::deque<std::shared_ptr<Item>> waiting_items_;

--- a/lib/shm_ipc/ItemWorker.hpp
+++ b/lib/shm_ipc/ItemWorker.hpp
@@ -95,6 +95,9 @@ public:
         distributor_socket_ = nullptr;
         disconnect_callback_();
         std::queue<ItemID>().swap(completed_items_);
+        if (zmq_error.num() == EINTR) {
+          stop();
+        }
       }
     }
     return nullptr;
@@ -109,6 +112,7 @@ private:
     assert(!distributor_socket_);
     distributor_socket_ =
         std::make_unique<zmq::socket_t>(context_, zmq::socket_type::req);
+    distributor_socket_->set(zmq::sockopt::linger, 0);
     distributor_socket_->connect(distributor_address_);
     send_register();
   }

--- a/lib/shm_ipc/ItemWorker.hpp
+++ b/lib/shm_ipc/ItemWorker.hpp
@@ -121,7 +121,8 @@ private:
     const std::string message_str =
         "REGISTER " + std::to_string(parameters_.stride) + " " +
         std::to_string(parameters_.offset) + " " +
-        to_string(parameters_.queue_policy) + " " + parameters_.client_name;
+        to_string(parameters_.queue_policy) + " " +
+        std::to_string(parameters_.group_id) + " " + parameters_.client_name;
     distributor_socket_->send(zmq::buffer(message_str));
     reset_heartbeat_time();
   }
@@ -175,7 +176,7 @@ private:
   std::unique_ptr<zmq::socket_t> distributor_socket_;
   DisconnectCallback disconnect_callback_;
 
-  const WorkerParameters parameters_{1, 0, WorkerQueuePolicy::QueueAll,
+  const WorkerParameters parameters_{1, 0, WorkerQueuePolicy::QueueAll, 0,
                                      "example_client"};
   std::set<ItemID> items_;
   std::queue<ItemID> completed_items_;

--- a/lib/shm_ipc/ItemWorkerProtocol.hpp
+++ b/lib/shm_ipc/ItemWorkerProtocol.hpp
@@ -120,6 +120,14 @@ struct WorkerParameters {
   size_t stride;
   size_t offset;
   WorkerQueuePolicy queue_policy;
+
+  /**
+   * Workers with the same group_id are treated as a group. The distributor will
+   * only send items to one worker of the group. This is useful for load
+   * sharing. Group_id 0 means no grouping.
+   */
+  size_t group_id;
+
   std::string client_name;
 };
 

--- a/test/shm_ipc/shm_ipc_demo.cpp
+++ b/test/shm_ipc/shm_ipc_demo.cpp
@@ -30,33 +30,35 @@ int main() {
 
   // The "storage" worker is slightly faster than data generation. It never
   // skips events but creates backpressure instead.
-  const WorkerParameters param1{1, 0, WorkerQueuePolicy::QueueAll, "storage"};
+  const WorkerParameters param1{1, 0, WorkerQueuePolicy::QueueAll, 0,
+                                "storage"};
   ExampleWorker worker1(worker_address, param1, d0 / 2, d0 / 4);
   std::thread worker1_thread(std::ref(worker1));
 
   // The "fast_analysis" worker is about as fast as data generation, but
   // includes a random time component. It may skip events sometimes.
-  const WorkerParameters param2{1, 0, WorkerQueuePolicy::PrebufferOne,
+  const WorkerParameters param2{1, 0, WorkerQueuePolicy::PrebufferOne, 0,
                                 "fast_analysis"};
   ExampleWorker worker2(worker_address, param2, d0 / 2, d0 / 2);
   std::thread worker2_thread(std::ref(worker2));
 
   // The "slow_analysis" worker is much slower than data generation. It always
   // waits for the newest dataset and skips all other items during processing.
-  const WorkerParameters param3{1, 0, WorkerQueuePolicy::Skip, "slow_analysis"};
+  const WorkerParameters param3{1, 0, WorkerQueuePolicy::Skip, 0,
+                                "slow_analysis"};
   ExampleWorker worker3(worker_address, param3, d0 * 2, d0 * 2);
   std::thread worker3_thread(std::ref(worker3));
 
   // The "sampling_analysis" worker receives only 1/5 of the data. It should be
   // fast enough, but it is not allowed to generate backpressure if not.
-  const WorkerParameters param4{5, 0, WorkerQueuePolicy::PrebufferOne,
+  const WorkerParameters param4{5, 0, WorkerQueuePolicy::PrebufferOne, 0,
                                 "sampling_analysis"};
   ExampleWorker worker4(worker_address, param4, d0 * 3, d0);
   std::thread worker4_thread(std::ref(worker4));
 
   // The "offset_sampler" worker receives only 1/4 of the data. It is also
   // not fast enough, and it is not allowed to generate backpressure.
-  const WorkerParameters param5{2, 1, WorkerQueuePolicy::PrebufferOne,
+  const WorkerParameters param5{2, 1, WorkerQueuePolicy::PrebufferOne, 0,
                                 "offset_sampler"};
   ExampleWorker worker5(worker_address, param5, d0 * 4, d0 * 1);
   std::thread worker5_thread(std::ref(worker5));
@@ -69,7 +71,7 @@ int main() {
   distributor = nullptr;
 
   // Elasticity test: add a worker
-  const WorkerParameters param6{1, 0, WorkerQueuePolicy::PrebufferOne,
+  const WorkerParameters param6{1, 0, WorkerQueuePolicy::PrebufferOne, 0,
                                 "fast_analysis_2"};
   ExampleWorker worker6(worker_address, param6, 50ms, 0ms);
   std::thread worker6_thread(std::ref(worker6));


### PR DESCRIPTION
This PR adds a shared memory timeslice output interface to tsclient. The interface is the same as to the original flesnet shared memory. As a new functionality, timeslice workers can specify a group_id, which is considered when distributing the timeslices.