### PR TITLE
msconsumer: compile on MacOS (no librt)

### DIFF
--- a/app/msconsumer/CMakeLists.txt
+++ b/app/msconsumer/CMakeLists.txt
@@ -5,8 +5,11 @@ add_executable(msconsumer msconsumer.cpp)
 target_compile_definitions(msconsumer PUBLIC BOOST_ALL_DYN_LINK)
 
 target_link_libraries(msconsumer
-  flib_ipc logging
-  ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} rt
-)
+    flib_ipc logging
+    ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+
+if(NOT APPLE)
+  target_link_libraries(msconsumer rt)
+endif()
 
 install(TARGETS msconsumer DESTINATION bin)


### PR DESCRIPTION
librt is not available and not needed on MacOS