### PR TITLE
Add zstd compression to archive files

### DIFF
--- a/app/tsclient/Application.cpp
+++ b/app/tsclient/Application.cpp
@@ -51,11 +51,21 @@ Application::Application(Parameters const& par,
     if (uri.scheme == "file" || uri.scheme.empty()) {
       size_t items = SIZE_MAX;
       size_t bytes = SIZE_MAX;
+      fles::ArchiveCompression compression = fles::ArchiveCompression::None;
       for (auto& [key, value] : uri.query_components) {
         if (key == "items") {
           items = stoull(value);
         } else if (key == "bytes") {
           bytes = stoull(value);
+        } else if (key == "c") {
+          if (value == "none") {
+            compression = fles::ArchiveCompression::None;
+          } else if (value == "zstd") {
+            compression = fles::ArchiveCompression::Zstd;
+          } else {
+            throw std::runtime_error(
+                "invalid compression type for scheme file: " + value);
+          }
         } else {
           throw std::runtime_error(
               "query parameter not implemented for scheme file: " + key);
@@ -64,10 +74,11 @@ Application::Application(Parameters const& par,
       const auto file_path = uri.authority + uri.path;
       if (items == SIZE_MAX && bytes == SIZE_MAX) {
         sinks_.push_back(std::unique_ptr<fles::TimesliceSink>(
-            new fles::TimesliceOutputArchive(file_path)));
+            new fles::TimesliceOutputArchive(file_path, compression)));
       } else {
         sinks_.push_back(std::unique_ptr<fles::TimesliceSink>(
-            new fles::TimesliceOutputArchiveSequence(file_path, items, bytes)));
+            new fles::TimesliceOutputArchiveSequence(file_path, items, bytes,
+                                                     compression)));
       }
 
     } else if (uri.scheme == "tcp") {

--- a/lib/fles_ipc/ArchiveDescriptor.hpp
+++ b/lib/fles_ipc/ArchiveDescriptor.hpp
@@ -18,6 +18,9 @@ enum class ArchiveType {
   RecoResultsArchive
 };
 
+/// The archive compression enum
+enum class ArchiveCompression { None, Zstd };
+
 template <class Base, class Derived, ArchiveType archive_type>
 class InputArchive;
 
@@ -34,8 +37,10 @@ public:
    *
    * \param archive_type The type of archive (e.g., timeslice, microslice).
    */
-  explicit ArchiveDescriptor(ArchiveType archive_type)
-      : archive_type_(archive_type) {
+  explicit ArchiveDescriptor(
+      ArchiveType archive_type,
+      ArchiveCompression archive_compression = ArchiveCompression::None)
+      : archive_type_(archive_type), archive_compression_(archive_compression) {
     time_created_ =
         std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     hostname_ = fles::system::current_hostname();
@@ -44,6 +49,11 @@ public:
 
   /// Retrieve the type of archive.
   [[nodiscard]] ArchiveType archive_type() const { return archive_type_; }
+
+  /// Retrieve the compression type of archive.
+  [[nodiscard]] ArchiveCompression archive_compression() const {
+    return archive_compression_;
+  }
 
   /// Retrieve the time of creation of the archive.
   [[nodiscard]] std::time_t time_created() const { return time_created_; }
@@ -73,12 +83,18 @@ private:
     } else {
       archive_type_ = ArchiveType::TimesliceArchive;
     };
+    if (version > 1) {
+      ar& archive_compression_;
+    } else {
+      archive_compression_ = ArchiveCompression::None;
+    };
     ar& time_created_;
     ar& hostname_;
     ar& username_;
   }
 
   ArchiveType archive_type_{};
+  ArchiveCompression archive_compression_{};
   std::time_t time_created_ = std::time_t();
   std::string hostname_;
   std::string username_;
@@ -88,5 +104,5 @@ private:
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-BOOST_CLASS_VERSION(fles::ArchiveDescriptor, 1)
+BOOST_CLASS_VERSION(fles::ArchiveDescriptor, 2)
 #pragma GCC diagnostic pop

--- a/lib/fles_ipc/OutputArchive.hpp
+++ b/lib/fles_ipc/OutputArchive.hpp
@@ -39,7 +39,8 @@ public:
     if (compression != ArchiveCompression::None) {
       out_ = std::make_unique<boost::iostreams::filtering_ostream>();
       if (compression == ArchiveCompression::Zstd) {
-        out_->push(boost::iostreams::zstd_compressor());
+        out_->push(boost::iostreams::zstd_compressor(
+            boost::iostreams::zstd::best_speed));
       } else {
         throw std::runtime_error(
             "Unsupported compression type for output archive file \"" +

--- a/lib/fles_ipc/OutputArchive.hpp
+++ b/lib/fles_ipc/OutputArchive.hpp
@@ -6,6 +6,8 @@
 #include "ArchiveDescriptor.hpp"
 #include "Sink.hpp"
 #include <boost/archive/binary_oarchive.hpp>
+#include <boost/iostreams/filter/zstd.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
 #include <fstream>
 #include <string>
 
@@ -23,9 +25,29 @@ public:
    *
    * \param filename File name of the archive file
    */
-  OutputArchive(const std::string& filename)
-      : ofstream_(filename, std::ios::binary), oarchive_(ofstream_) {
-    oarchive_ << descriptor_;
+  explicit OutputArchive(
+      const std::string& filename,
+      ArchiveCompression compression = ArchiveCompression::None)
+      : ofstream_(filename, std::ios::binary), descriptor_{archive_type,
+                                                           compression} {
+
+    oarchive_ = std::make_unique<boost::archive::binary_oarchive>(ofstream_);
+
+    *oarchive_ << descriptor_;
+
+    if (compression != ArchiveCompression::None) {
+      out_ = std::make_unique<boost::iostreams::filtering_ostream>();
+      if (compression == ArchiveCompression::Zstd) {
+        out_->push(boost::iostreams::zstd_compressor());
+      } else {
+        throw std::runtime_error(
+            "Unsupported compression type for output archive file \"" +
+            filename + "\"");
+      }
+      out_->push(ofstream_);
+      oarchive_ = std::make_unique<boost::archive::binary_oarchive>(
+          *out_, boost::archive::no_header);
+    }
   }
 
   /// Delete copy constructor (non-copyable).
@@ -38,14 +60,13 @@ public:
   /// Store an item.
   void put(std::shared_ptr<const Base> item) override { do_put(*item); }
 
-  void end_stream() override { ofstream_.close(); }
-
 private:
   std::ofstream ofstream_;
-  boost::archive::binary_oarchive oarchive_;
-  ArchiveDescriptor descriptor_{archive_type};
+  std::unique_ptr<boost::iostreams::filtering_ostream> out_;
+  std::unique_ptr<boost::archive::binary_oarchive> oarchive_;
+  ArchiveDescriptor descriptor_;
 
-  void do_put(const Derived& item) { oarchive_ << item; }
+  void do_put(const Derived& item) { *oarchive_ << item; }
   // TODO(Jan): Solve this without the additional alloc/copy operation
 };
 

--- a/lib/fles_ipc/OutputArchive.hpp
+++ b/lib/fles_ipc/OutputArchive.hpp
@@ -24,6 +24,7 @@ public:
    * for writing, and write the archive descriptor.
    *
    * \param filename File name of the archive file
+   * \param compression Compression type to use
    */
   explicit OutputArchive(
       const std::string& filename,

--- a/lib/fles_ipc/OutputArchiveSequence.hpp
+++ b/lib/fles_ipc/OutputArchiveSequence.hpp
@@ -129,7 +129,8 @@ private:
     if (descriptor_.archive_compression() != ArchiveCompression::None) {
       out_ = std::make_unique<boost::iostreams::filtering_ostream>();
       if (descriptor_.archive_compression() == ArchiveCompression::Zstd) {
-        out_->push(boost::iostreams::zstd_compressor());
+        out_->push(boost::iostreams::zstd_compressor(
+            boost::iostreams::zstd::best_speed));
       } else {
         throw std::runtime_error(
             "Unsupported compression type for output archive file \"" +

--- a/lib/fles_ipc/OutputArchiveSequence.hpp
+++ b/lib/fles_ipc/OutputArchiveSequence.hpp
@@ -7,6 +7,8 @@
 #include "Sink.hpp"
 #include <boost/algorithm/string.hpp>
 #include <boost/archive/binary_oarchive.hpp>
+#include <boost/iostreams/filter/zstd.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iomanip>
@@ -33,10 +35,13 @@ public:
    * \param filename_template File name pattern of the archive files
    * \param items_per_file    Number of items to store in each file
    */
-  OutputArchiveSequence(std::string filename_template,
-                        std::size_t items_per_file = SIZE_MAX,
-                        std::size_t bytes_per_file = SIZE_MAX)
-      : filename_template_(std::move(filename_template)),
+  explicit OutputArchiveSequence(
+      std::string filename_template,
+      std::size_t items_per_file = SIZE_MAX,
+      std::size_t bytes_per_file = SIZE_MAX,
+      ArchiveCompression compression = ArchiveCompression::None)
+      : descriptor_{archive_type, compression},
+        filename_template_(std::move(filename_template)),
         items_per_file_(items_per_file), bytes_per_file_(bytes_per_file) {
     if (items_per_file_ == 0) {
       items_per_file_ = SIZE_MAX;
@@ -66,13 +71,15 @@ public:
 
   void end_stream() override {
     oarchive_ = nullptr;
+    out_ = nullptr;
     ofstream_ = nullptr;
   }
 
 private:
   std::unique_ptr<std::ofstream> ofstream_;
+  std::unique_ptr<boost::iostreams::filtering_ostream> out_;
   std::unique_ptr<boost::archive::binary_oarchive> oarchive_;
-  ArchiveDescriptor descriptor_{archive_type};
+  ArchiveDescriptor descriptor_;
 
   std::string filename_template_;
   std::size_t items_per_file_;
@@ -112,11 +119,26 @@ private:
 
   void next_file() {
     oarchive_ = nullptr;
+    out_ = nullptr;
     ofstream_ = nullptr;
     ofstream_ = std::make_unique<std::ofstream>(filename(file_count_),
                                                 std::ios::binary);
     oarchive_ = std::make_unique<boost::archive::binary_oarchive>(*ofstream_);
     *oarchive_ << descriptor_;
+
+    if (descriptor_.archive_compression() != ArchiveCompression::None) {
+      out_ = std::make_unique<boost::iostreams::filtering_ostream>();
+      if (descriptor_.archive_compression() == ArchiveCompression::Zstd) {
+        out_->push(boost::iostreams::zstd_compressor());
+      } else {
+        throw std::runtime_error(
+            "Unsupported compression type for output archive file \"" +
+            filename(file_count_) + "\"");
+      }
+      out_->push(*ofstream_);
+      oarchive_ = std::make_unique<boost::archive::binary_oarchive>(
+          *out_, boost::archive::no_header);
+    }
 
     ++file_count_;
     file_item_count_ = 0;


### PR DESCRIPTION
This PR modifies InputArchive, OutputArchive, and OutputArchiveSequence to support optional zstd compression of the data contents.

Whether data in an archive file is compressed is documented using a new member variable of the ArchiveDescriptor. Compression is switched off by default and can be enabled in tsclient using the "?c=zstd" parameter in the output uri. Reading from an archive file automatically decompresses if neccessary.

The zstd compression has a throughput of approximately 92 MB/s on the mFLES login node (using a single core).