### PR TITLE
fles_ipc: deprecate TimesliceMultiInputArchive and -Subscriber

### DIFF
--- a/lib/fles_ipc/TimesliceMultiInputArchive.hpp
+++ b/lib/fles_ipc/TimesliceMultiInputArchive.hpp
@@ -14,11 +14,11 @@
 
 namespace fles {
 /**
- * \brief The TimesliceMultiInputArchive class reads timeslice data from
- * several TimesliceInputArchives and returns the timslice with the
- * smallest index.
+ * \brief The (deprecated) TimesliceMultiInputArchive class reads
+ * timeslice data from several TimesliceInputArchives and returns the
+ * timslice with the smallest index.
  */
-class TimesliceMultiInputArchive : public TimesliceSource {
+  class [[deprecated("Replaced by TimeSliceAutoSource")]] TimesliceMultiInputArchive : public TimesliceSource {
 public:
   // Construct an input archive object for each of the files passed in the input
   // string open the archive files for reading, and read the archive descriptors

--- a/lib/fles_ipc/TimesliceMultiSubscriber.hpp
+++ b/lib/fles_ipc/TimesliceMultiSubscriber.hpp
@@ -14,10 +14,11 @@
 
 namespace fles {
 /**
- * \brief The TimesliceMultiSubscriber class receives serialized timeslice data
- * from several zeromq socket and returns the timeslice with the smallest index.
+ * \brief The (deprecated) TimesliceMultiSubscriber class receives
+ * serialized timeslice data from several zeromq socket and returns
+ * the timeslice with the smallest index.
  */
-class TimesliceMultiSubscriber : public TimesliceSource {
+class [[deprecated("Replaced by TimeSliceAutoSource")]] TimesliceMultiSubscriber : public TimesliceSource {
 public:
   /// Construct timeslice subscriber receiving from given ZMQ address.
   explicit TimesliceMultiSubscriber(const std::string& /*inputString*/,


### PR DESCRIPTION
Declare the two classes TimesliceMultiInputArchive and TimesliceMultiSubscriber as depracted as they are replaced by TimeSliceAutoSource (see also the discussion of #PR126).