### PR TITLE
Introduces zstd support switch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2013-2021 Jan de Cuveland <cmail@cuveland.de>
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.16)
 project(flesnet DESCRIPTION "CBM FLES Timeslice Building" VERSION 0.0 LANGUAGES CXX)
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "bin")
 

--- a/lib/fles_ipc/CMakeLists.txt
+++ b/lib/fles_ipc/CMakeLists.txt
@@ -4,6 +4,41 @@
 file(GLOB LIB_SOURCES *.cpp)
 file(GLOB LIB_HEADERS *.hpp)
 
+#------------------------------------------------------------------------------#
+set(OLD_CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS})
+set(OLD_CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
+set(OLD_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+
+#set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS} BOOST_ALL_DYN_LINK)
+set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${Boost_INCLUDE_DIRS})
+set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${Boost_IOSTREAMS_LIBRARY})
+
+# Check if the Boost iostream was compiled with ZSTD (un)compression support
+CHECK_CXX_SOURCE_COMPILES("
+#include <boost/iostreams/filter/zstd.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+
+int main(int argc, char *argv[])
+{
+  std::unique_ptr<boost::iostreams::filtering_istream> in_;
+  in_ = std::make_unique<boost::iostreams::filtering_istream>();
+  in_->push(boost::iostreams::zstd_decompressor());
+
+  return 0;
+}" BOOST_IOS_HAS_ZSTD)
+
+if(BOOST_IOS_HAS_ZSTD)
+  message(STATUS "=> Boost::iostream with ZSTD filter found.")
+  add_compile_definitions(BOOST_IOS_HAS_ZSTD)
+else()
+  message(STATUS "=> Boost::iostream does not support ZSTD filter.")
+endif()
+
+set(CMAKE_REQUIRED_DEFINITIONS ${OLD_CMAKE_REQUIRED_DEFINITIONS})
+set(CMAKE_REQUIRED_INCLUDES ${OLD_CMAKE_REQUIRED_INCLUDES})
+set(CMAKE_REQUIRED_LIBRARIES ${OLD_CMAKE_REQUIRED_LIBRARIES})
+#------------------------------------------------------------------------------#
+
 add_library(fles_ipc ${LIB_SOURCES} ${LIB_HEADERS})
 
 target_compile_definitions(fles_ipc PUBLIC BOOST_ALL_DYN_LINK)


### PR DESCRIPTION
- Check with a `CMake` compile-link test if `boost::iostream` provides the `zstd` filtering
- Enable `ZSTD` (un)compression only if it is the case, using some preprocessor variable set from `CMake`

This scheme could probably be also used for other compression filters such as `LZMA`, allowing to tune allowed filters depending on what is available on current node

This is the patch proposed in https://git.cbm.gsi.de/j.decuveland/cbmroot/-/merge_requests/2, but applied directly to `Flesnet`

- Follow-up of #132 
- Part of user-feedback from CBM-TOF to #116  