### PR TITLE
add missing sstream includes and minor improvements in affected file

### DIFF
--- a/lib/fles_zeromq/ComponentSenderZeromq.cpp
+++ b/lib/fles_zeromq/ComponentSenderZeromq.cpp
@@ -1,12 +1,15 @@
 // Copyright 2012-2013, 2016 Jan de Cuveland <cmail@cuveland.de>
+// Copyright 2024 Florian Schintke <schintke@zib.de>
 
 #include "ComponentSenderZeromq.hpp"
 #include "MicrosliceDescriptor.hpp"
+#include "RingBufferView.hpp"
 #include "System.hpp"
 #include "Utility.hpp"
 #include "log.hpp"
 #include <algorithm>
 #include <iomanip>
+#include <sstream>
 
 ComponentSenderZeromq::ComponentSenderZeromq(
     uint64_t input_index,


### PR DESCRIPTION
A modern clang++ compiler complains about missing sstream includes in the two modified files.

We add some further includes for better self-containment.

For lib/fles_libfabric/InputChannelSender.cpp we add minor code modernizations and clarifications hinted by clang-tidy.