### PR TITLE
Disable PDA tests unless USE_PDA 

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,10 +98,12 @@ if(BASH_PROGRAM)
   add_test(NAME test_mstool
            COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test_mstool.sh
            WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-  if (NOT APPLE)
-    add_test(NAME test_with_pda
+  if (USE_PDA)
+    if (NOT APPLE)
+      add_test(NAME test_with_pda
              COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test_with_pda.sh
              WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
FLESnet is build without PDA, the test with PDA unnecessarily keeps failing. After some consideration, I decided not to disable the test if the only reason FLESnet is build without PDA is that PDA is not found. This serves as a reminder to the user to ensure that USE_PDA is set to some appropriate value when building without PDA.