### PR TITLE
Experimental timeslice release mode for tsclient

### DIFF
--- a/app/tsclient/Application.cpp
+++ b/app/tsclient/Application.cpp
@@ -2,6 +2,7 @@
 
 #include "Application.hpp"
 #include "ManagedTimesliceBuffer.hpp"
+#include "StorableTimeslice.hpp"
 #include "Timeslice.hpp"
 #include "TimesliceAnalyzer.hpp"
 #include "TimesliceAutoSource.hpp"
@@ -190,7 +191,13 @@ void Application::run() {
       ++index;
       continue;
     }
-    std::shared_ptr<const fles::Timeslice> ts(std::move(timeslice));
+    std::shared_ptr<const fles::Timeslice> ts;
+    if (par_.release_mode()) {
+      ts = std::make_shared<const fles::StorableTimeslice>(*timeslice);
+      timeslice.reset();
+    } else {
+      ts = std::shared_ptr<const fles::Timeslice>(std::move(timeslice));
+    }
     if (par_.native_speed() != 0.0) {
       native_speed_delay(ts->start_time());
     }

--- a/app/tsclient/Parameters.cpp
+++ b/app/tsclient/Parameters.cpp
@@ -86,6 +86,9 @@ void Parameters::parse_options(int argc, char* argv[]) {
            "limit the item rate to given frequency (in Hz)");
   desc_add("speed", po::value<double>(&native_speed_)->value_name("X"),
            "limit the item rate to given factor of original speed");
+  desc_add("release-mode,R",
+           po::value<bool>(&release_mode_)->implicit_value(true),
+           "copy and release each timeslice immediately after receiving it");
 
   po::variables_map vm;
   po::store(po::parse_command_line(argc, argv, desc), vm);

--- a/app/tsclient/Parameters.hpp
+++ b/app/tsclient/Parameters.hpp
@@ -49,6 +49,8 @@ public:
 
   [[nodiscard]] double native_speed() const { return native_speed_; }
 
+  [[nodiscard]] bool release_mode() const { return release_mode_; }
+
 private:
   void parse_options(int argc, char* argv[]);
 
@@ -66,4 +68,5 @@ private:
   uint64_t stride_ = 1;
   double rate_limit_ = 0.0;
   double native_speed_ = 0.0;
+  bool release_mode_ = false;
 };


### PR DESCRIPTION
Unexpected fluctuations in the time that a `tsclient` binary configured for timeslice publishing through zeromq blocks a given timeslice were observed during the May 2024 mCBM campaign.

This MR implements an experimental new timeslice release mode in which `tsclient` copies and immediately releases each received timeslice. It is activated with the new `-R` option of `tsclient`.