### PR TITLE
Add magic(5) support for Boost binary archives

### DIFF
--- a/contrib/boost-magic
+++ b/contrib/boost-magic
@@ -1,0 +1,16 @@
+# File magic for Boost binary serialization archives.
+# 2024-06-12, Jan de Cuveland <cuveland@compeng.uni-frankfurt.de>
+
+# Copy this file to /etc/magic ot $HOME/.magic to enable magic(5) support.
+# The magic is used by the file(1) command to detect Boost serialization binary archives.
+
+0     quad    22
+>8    string  serialization::archive   Boost binary %s.
+>>30  short   x                        Library version: %d
+
+# Hints on FairSoft compatibility:
+>>>30 short <17 (any FairSoft)
+>>>30 short 17  (FairSoft jun19 or newer)
+>>>30 short 18  (FairSoft apr21 or newer)
+>>>30 short 19  (FairSoft apr22 or newer)
+>>>30 short >19 (no FairSoft of today, 2024-06-12)


### PR DESCRIPTION
It is sometimes useful to check the BOOST_ARCHIVE_VERSION of a binary Boost serialization::archive (e.g., .tsa file).

Inspired by this [MR](https://git.cbm.gsi.de/computing/cbmroot/-/merge_requests/1753) by @PALoizeau, the provided file adds support to the popular `file` command.

It does not need to be compiled, and thus does not depend on the installed FairSoft version. To avoid the need for installation, it could also be wrapped in a 1-line shell script that calls `file` with the `-m magicfile` option.