### PR TITLE
let ZMQ build with modern cmake versions (4.0.3), remove compiler flag -msse4.2 on arm64 systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,11 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_compile_options(-msse4.2 -Wall -Wpedantic -Wextra -Winit-self -Wundef -Wold-style-cast -Woverloaded-virtual -Wwrite-strings -Wnon-virtual-dtor -fno-omit-frame-pointer)
+if( NOT "arm64" STREQUAL ${CMAKE_SYSTEM_PROCESSOR} )
+    add_compile_options(-msse4.2)
+endif()
+
+add_compile_options(-Wall -Wpedantic -Wextra -Winit-self -Wundef -Wold-style-cast -Woverloaded-virtual -Wwrite-strings -Wnon-virtual-dtor -fno-omit-frame-pointer)
 
 if (COVERALLS)
   include(Coveralls)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Jan de Cuveland <cmail@cuveland.de>
+# Copyright 2013-2025 Jan de Cuveland <cmail@cuveland.de>
 
 cmake_minimum_required(VERSION 3.16)
 project(flesnet DESCRIPTION "CBM FLES Timeslice Building" VERSION 0.0 LANGUAGES CXX)
@@ -57,6 +57,8 @@ if(INCLUDE_ZMQ)
     GIT_TAG "622fc6dde99ee172ebaa9c8628d85a7a1995a21d" # v4.3.5
     GIT_CONFIG advice.detachedHead=false
     CMAKE_CACHE_ARGS
+    # override ZMQ's cmake version allowing builds with modern cmakes
+    -DCMAKE_POLICY_VERSION_MINIMUM:STRING=3.16
     -DCMAKE_SUPPRESS_DEVELOPER_WARNINGS:BOOL=TRUE
     -DWITH_LIBBSD:BOOL=FALSE
     -DWITH_LIBSODIUM:BOOL=FALSE


### PR DESCRIPTION
override cmake version for ZMQ build with newer minimum version

modern cmakes dropped support for old cmake_minimum_required() versions (< 3.5, deprecation warning for < 3.10). The ZMQ version we clone requested support for old cmake versions 3.0.2 or even 2.8.12. We override this by emitting a newer cmake_minimum_required to the custom cmake cache for building ZMQ.

suppress -msse4.2 on arm64 systems to build with less warnings

ARM systems do not have support for sse4.2, so the compiler option -msse4.2 does not help, but raises a warning for many source files compiled.

We do no longer add this option when the system processor is an arm64.