### PR TITLE
add variant of the L_ macro that also prints FILE, LINE, and func

### DIFF
--- a/lib/logging/log.hpp
+++ b/lib/logging/log.hpp
@@ -55,4 +55,8 @@ public:
 };
 } // namespace logging
 
+// For a debug build, you can log from where in the sources each message came from.
+// Unfortunately, it does not help too much for globally catched errors.
+// Just uncomment the following line and comment the next one instead.
+// #define L_(severity) BOOST_LOG_SEV(g_logger::get(), severity) << __FILE__ << ":" << __LINE__ << ":" << __func__ << "(): "
 #define L_(severity) BOOST_LOG_SEV(g_logger::get(), severity)


### PR DESCRIPTION
For debugging, it can be helful to see in log messages where in the code the message was produced. We add a commented-out variant of the log macro that one can locally activate in the code for debugging that includes in log entries the __FILE__, __LINE__, and __func__ information.