### PR TITLE
update Flesnet spelling akin to "CBM TDR Online Systems - Part I"

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,4 +1,4 @@
-FLESnet usage for FLIB stand alone readout
+Flesnet usage for FLIB stand alone readout
 ==========================================
 
 Note: this document has not been updated for CRI operation so far.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-Installing FLESnet
+Installing Flesnet
 ==================
 
 General remarks: OS and Software Environment
@@ -188,13 +188,13 @@ programming scripts are provided (see [HOWTO.md](HOWTO.md)).
 To use these scripts install the Xilinx Vivado Lab Tools or any other
 Vivado edition.
 
-Legacy FLIB readout with FLESnet
-==================================
+Legacy FLIB readout with Flesnet
+================================
 
 Flesnet Version
 ---------------
 
-The legacy readout isn't supported in newer versions of flesnet
+The legacy readout is not supported in newer versions of Flesnet
 anymore. Versions still supporting the legacy readout are tagged in
 the repository. The naming schema for these tags is legacy-ro-vX.X. If
 serious issues are fixed a new tag will be created.

--- a/contrib/grafana_dashboards/flesnet-data-rates-details_portable.json
+++ b/contrib/grafana_dashboards/flesnet-data-rates-details_portable.json
@@ -629,7 +629,7 @@
         ]
     },
     "timezone": "",
-    "title": "FLESnet Data Rates Details",
+    "title": "Flesnet Data Rates Details",
     "uid": "RwuG37zMz",
     "version": 1
 }

--- a/contrib/grafana_dashboards/flesnet-overview_portable.json
+++ b/contrib/grafana_dashboards/flesnet-overview_portable.json
@@ -3251,7 +3251,7 @@
         ]
     },
     "timezone": "",
-    "title": "FLESNET Overview",
+    "title": "Flesnet Overview",
     "uid": "dVag0c9Wz",
     "version": 1,
     "weekStart": ""

--- a/doc/flesnet_minimal_example.md
+++ b/doc/flesnet_minimal_example.md
@@ -1,4 +1,4 @@
-# Minimal Example Illustrating the Use of FLESnet
+# Minimal Example Illustrating the Use of Flesnet
 ## Prerequisites
 For these examples, you will need the `mstool`, `flesnet` and `tsclient` binaries.
 
@@ -34,16 +34,16 @@ First, we will use the `mstool` again to provide microslices using a named share
 ```
 Keep this terminal open.
 
-With our shared memory microslice input source ready, we can start FLESnet. In this most simple example, we will start FLESnet so that one entry node and one build node is represented using one FLESnet process.
+With our shared memory microslice input source ready, we can start Flesnet. In this most simple example, we will start Flesnet so that one entry node and one build node is represented using one Flesnet process.
 
 ```
 ./flesnet -t zeromq -i 0 -I shm:/fles_in_shared_memory/0 -o 0 -O shm:fles_out_shared_memory/0 --timeslice-size 20 --processor-instances 1 -e "./tsclient -i shm:%s -o file:timeslice_archive.tsa -n 15"
 ```
 
-- `-t`: We are using the ZeroMQ transport layer to exchange information between entry and build nodes. This makes more sense when we use seperate FLESnet instances for entry and build nodes. Here, this singke process will do the work of both.
-- `-i`: The input index of this `flesnet` instance. Example: When `-i` is set to 2, this entry node will read from the 3rd (indexing starts at 0) input source, defined with the `-I` flag. Again, this makes more sense when having seperate entry and build nodes.
+- `-t`: We are using the ZeroMQ transport layer to exchange information between entry and build nodes. This makes more sense when we use separate Flesnet instances for entry and build nodes. Here, this single process will do the work of both.
+- `-i`: The input index of this `flesnet` instance. Example: When `-i` is set to 2, this entry node will read from the 3rd (indexing starts at 0) input source, defined with the `-I` flag. Again, this makes more sense when having separate entry and build nodes.
 - `I`: List of input sources. See use of `-i` flag.
-- `-o`: Output index. Simililar to the `-i` flag, but refers to the output sink of this FLESnet instance. Example: When `-o` is set to 1, this build node will write the built timeslices into the 2nd (indexing starts at 0) output sink, defined with the `-O` flag. Again, this makes more sense, when having seperate entry and build nodes. 
+- `-o`: Output index. Similar to the `-i` flag, but refers to the output sink of this Flesnet instance. Example: When `-o` is set to 1, this build node will write the built timeslices into the 2nd (indexing starts at 0) output sink, defined with the `-O` flag. Again, this makes more sense, when having separate entry and build nodes. 
 - `-O`: List of output sinks. See use of `-o` flag.
 - `--timeslice-size`: Defines how many microslices will make up one timeslice (This does not include overlap. The overlap concept will be explained within a dedicated section).
 - `--processor-instances`: The amount of `-e` executions.

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -10,7 +10,7 @@ These dashboards correspond to the ones used in the mCBM beam campaign 2022, exp
 portable data-source names instead of hashes specific to the local `Grafana to InfluxDB` configuration.
 
 This HowTo will explain:
-- the installation and configuration of recent versions of InfluxDB to be compatible with the FLESnet monitoring
+- the installation and configuration of recent versions of InfluxDB to be compatible with the Flesnet monitoring
 - the installation and configuration of recent versions of Grafana to be compatible with the the InfluxDB setup in
   previous step
 - the importation of the dashboards in Grafana
@@ -235,12 +235,12 @@ Detailled back-pressure monitoring for a single selected EN and a choice of its 
 
 TODO
 
-#### FLESNET Overview
+#### Flesnet Overview
 
 Main monitoring panel: total data rate, data rate per system, microslice-rate per link, timeslice building buffers usage
 
 TODO
 
-#### FLESnet Data Rates Details
+#### Flesnet Data Rates Details
 
 TODO

--- a/doc/monitoring_with_podman.md
+++ b/doc/monitoring_with_podman.md
@@ -133,7 +133,7 @@ Repeat for Databases `cri_status` and `tsclient_status`
 
 ![Grafana-influxqlanguage.png](./img/Grafana-influxqlanguage.png)
 
-## Connecting FLESnet and other to InfluxDB
+## Connecting Flesnet and other to InfluxDB
 
 Processes can be connected to the InfluxDB using the `-m` flag:
 


### PR DESCRIPTION
For the "CBM TDR Online Systems - Part I", we used the spelling 'Flesnet' instead of the older 'FLESnet' or 'FLESNET' spelling. We update such occurrences to 'Flesnet'. Now, two spellings remain used: 'Flesnet' and 'flesnet', the latter, for example, to refer to the command line tool (but not exclusively for that purpose).