### PR TITLE
Make flesnet's command-line option '-e' optional

### DIFF
--- a/app/flesnet/Parameters.cpp
+++ b/app/flesnet/Parameters.cpp
@@ -1,4 +1,5 @@
 // Copyright 2012-2013 Jan de Cuveland <cmail@cuveland.de>
+// Copyright 2025 Florian Schintke <schintke@zib.de>
 
 #include "Parameters.hpp"
 #include "GitRevision.hpp"
@@ -126,9 +127,10 @@ void Parameters::parse_options(int argc, char* argv[]) {
   config_add("max-timeslice-number,n",
              po::value<uint32_t>(&max_timeslice_number_)->value_name("<n>"),
              "quit after processing given number of timeslices");
-  config_add(
-      "processor-executable,e",
-      po::value<std::string>(&processor_executable_)->value_name("<string>"),
+  config_add("processor-executable,e",
+             po::value<std::string>(&processor_executable_)
+                 ->default_value(processor_executable_)
+                 ->value_name("<string>"),
       "name of the executable acting as timeslice processor");
   config_add("processor-instances",
              po::value<uint32_t>(&processor_instances_)

--- a/app/flesnet/Parameters.hpp
+++ b/app/flesnet/Parameters.hpp
@@ -1,4 +1,5 @@
 // Copyright 2012-2013 Jan de Cuveland <cmail@cuveland.de>
+// Copyright 2025 Florian Schintke <schintke@zib.de>
 #pragma once
 
 #include <cstdint>
@@ -149,7 +150,10 @@ private:
   uint32_t max_timeslice_number_ = UINT32_MAX;
 
   /// The name of the executable acting as timeslice processor.
-  std::string processor_executable_;
+  // The default value "true" calls the UNIX command 'true' as a dummy.
+  // An actual processor can then be started in a separate command and
+  // does not not need to be spawned by the flesnet process itself.
+  std::string processor_executable_ = "true";
 
   /// The number of instances of the timeslice processor executable.
   uint32_t processor_instances_ = 1;


### PR DESCRIPTION
The command-line option '-e' did not have a default value, so that a command to start a timeslice processor was mandatory on the command line.

This makes the use of flesnet less flexible than possible. Actually, it is not necessary that flesnet initiates the timeslice processor itself. This can be done asynchronously and independently if desirable.

For example, in the future scenario of timeslice forwarding, we may want to start the forwarder more flexible in job scripts by other means. So, requiring to do that via the '-e' option feels restrictive and introduces unnecessary coupling in the tool chain.

Now, we provide a default value for the '-e' option, which make that option optional on the command line. We use "true" as the default value, which means that flesnet simply calls the UNIX binary 'true' as dummy timeslice processor.