### PR TITLE
fix .clang-tidy and warnings for [readability-redundant-member-init]

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -101,7 +101,7 @@ Checks: >
   modernize-use-override,
   modernize-use-transparent-functors,
   modernize-use-uncaught-exceptions,
-  modernize-use-using.
+  modernize-use-using,
   performance-unnecessary-value-param,
   readability-braces-around-statements,
   readability-container-data-pointer,

--- a/lib/fles_core/TimesliceBuffer.hpp
+++ b/lib/fles_core/TimesliceBuffer.hpp
@@ -110,7 +110,7 @@ public:
 
 private:
   std::string shm_identifier_;    ///< shared memory identifier
-  boost::uuids::uuid shm_uuid_{}; ///< shared memory UUID
+  boost::uuids::uuid shm_uuid_;   ///< shared memory UUID
   uint32_t data_buffer_size_exp_; ///< 2's exponent of data buffer size in bytes
   uint32_t desc_buffer_size_exp_; ///< 2's exponent of descriptor buffer size
                                   ///< in units of TimesliceComponentDescriptors

--- a/lib/fles_ipc/TimesliceShmWorkItem.hpp
+++ b/lib/fles_ipc/TimesliceShmWorkItem.hpp
@@ -24,7 +24,7 @@ namespace fles {
  */
 struct TimesliceShmWorkItem {
   /// The UUID of the containing managed shared memory
-  boost::uuids::uuid shm_uuid{};
+  boost::uuids::uuid shm_uuid;
   /// The identifier string of the containing managed shared memory
   std::string shm_identifier;
   /// The timeslice descriptor

--- a/lib/monitoring/Monitor.hpp
+++ b/lib/monitoring/Monitor.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-// (C) Copyright 2021 GSI Helmholtzzentrum für Schwerionenforschung
+// (C) Copyright 2021, 2025 GSI Helmholtzzentrum für Schwerionenforschung
 // Original author: Walter F.J. Mueller <w.f.j.mueller@gsi.de>
 
 #ifndef included_Cbm_Monitor
@@ -68,17 +68,17 @@ private:
   using sink_uptr_t = std::unique_ptr<MonitorSink>;
   using smap_t = std::unordered_map<std::string, sink_uptr_t>;
 
-  std::thread fThread{};              //!< worker thread
+  std::thread fThread;                //!< worker thread
   std::condition_variable fControlCV; //!< condition variable for thread control
-  std::mutex fControlMutex{};         //!< mutex for thread control
+  std::mutex fControlMutex;           //!< mutex for thread control
   bool fStopped{false};               //!< signals thread rundown
 
-  metvec_t fMetVec{};          //!< metric list
-  std::mutex fMetVecMutex{};   //!< mutex for fMetVec access
+  metvec_t fMetVec;            //!< metric list
+  std::mutex fMetVecMutex;     //!< mutex for fMetVec access
   std::string fHostName;       //!< hostname
-  smap_t fSinkMap{};           //!< sink registry
-  std::mutex fSinkMapMutex{};  //!< mutex for fSinkMap access
-  time_point fNextHeartbeat{}; //!< time of next heartbeat
+  smap_t fSinkMap;             //!< sink registry
+  std::mutex fSinkMapMutex;    //!< mutex for fSinkMap access
+  time_point fNextHeartbeat;   //!< time of next heartbeat
   static Monitor* fpSingleton; //!< \glos{singleton} this
 };
 


### PR DESCRIPTION
Fix a formatting error in .clang-tidy ('.' instead of ',') and fix some redundant member inits clang-tidy was complaining.