### PR TITLE
update and improve infos on boost archive versions and errors

### DIFF
--- a/contrib/boost-magic
+++ b/contrib/boost-magic
@@ -13,4 +13,5 @@
 >>>30 short 17  (FairSoft jun19 or newer)
 >>>30 short 18  (FairSoft apr21 or newer)
 >>>30 short 19  (FairSoft apr22 or newer)
->>>30 short >19 (no FairSoft of today, 2024-06-12)
+>>>30 short 20  (FairSoft apr21 or newer)
+>>>30 short >20 (no FairSoft of today, 2025-07-21)

--- a/doc/boost_serialization.txt
+++ b/doc/boost_serialization.txt
@@ -34,6 +34,10 @@ Boost version | BOOST_ARCHIVE_VERSION
 1.82 | 19
 1.83 | 19
 1.84 | 20
+1.85 | 20
+1.86 | 20
+1.87 | 20
+1.88 | 20
 dev  | 20
 
 - List of BOOST_ARCHIVE_VERSION changes:

--- a/lib/fles_ipc/ArchiveDescriptor.hpp
+++ b/lib/fles_ipc/ArchiveDescriptor.hpp
@@ -1,4 +1,5 @@
 // Copyright 2013 Jan de Cuveland <cmail@cuveland.de>
+// Copyright 2025 Florian Schintke <schintke@zib.de>
 /// \file
 /// \brief Defines the fles::ArchiveDescriptor class.
 #pragma once
@@ -19,8 +20,28 @@ enum class ArchiveType {
   QaDataArchive
 };
 
+constexpr const char* ArchiveTypeToString(ArchiveType e) noexcept
+{
+    switch (e) {
+    case ArchiveType::TimesliceArchive: return "TimesliceArchive";
+    case ArchiveType::MicrosliceArchive: return "MicrosliceArchive";
+    case ArchiveType::RecoResultsArchive: return "RecoResultsArchive";
+    case ArchiveType::QaDataArchive: return "QaDataArchive";
+    default: return "unknown archive type";
+    }
+}
+
 /// The archive compression enum
 enum class ArchiveCompression { None, Zstd };
+
+constexpr const char* ArchiveCompressionToString(ArchiveCompression e) noexcept
+{
+    switch (e) {
+    case ArchiveCompression::None: return "None";
+    case ArchiveCompression::Zstd: return "Zstd";
+    default: return "unknown compression type";
+    }
+}
 
 template <class Base, class Derived, ArchiveType archive_type>
 class InputArchive;

--- a/lib/fles_ipc/InputArchiveLoop.hpp
+++ b/lib/fles_ipc/InputArchiveLoop.hpp
@@ -1,15 +1,19 @@
 // Copyright 2013, 2015, 2016 Jan de Cuveland <cmail@cuveland.de>
+// Copyright 2025 Florian Schintke <schintke@zib.de>
 /// \file
 /// \brief Defines the fles::InputArchiveLoop template class.
 #pragma once
 
 #include "ArchiveDescriptor.hpp"
+#include "BoostHelper.hpp"
 #include "Source.hpp"
+#include "log.hpp"
 #include <boost/archive/binary_iarchive.hpp>
 #ifdef BOOST_IOS_HAS_ZSTD
 #include <boost/iostreams/filter/zstd.hpp>
 #endif
 #include <boost/iostreams/filtering_stream.hpp>
+#include <boost/version.hpp>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -66,13 +70,38 @@ private:
       throw std::ios_base::failure("error opening file \"" + filename_ + "\"");
     }
 
-    iarchive_ = std::make_unique<boost::archive::binary_iarchive>(*ifstream_);
+    try {
+      iarchive_ = std::make_unique<boost::archive::binary_iarchive>(*ifstream_);
+    } catch (boost::archive::archive_exception const &e) {
+      switch (e.code) {
+      case boost::archive::archive_exception::unsupported_version:
+        L_(warning) << "This executable has support up to archive version "
+                    << boost::archive::BOOST_ARCHIVE_VERSION() << std::endl;
+        L_(warning) << "Consider recompiling with BOOST library >="
+                    << boostlib_for_archive_version(
+                      // future improvement: better query for the
+                      // version found in the failed archive, but
+                      // there seems no easy way to do that. So, we
+                      // propose to use at least a boost library
+                      // version supporting the next archive version.
+                      boost::archive::BOOST_ARCHIVE_VERSION()+1)
+                    << " (this uses boost " << BOOST_LIB_VERSION << ")." << std::endl;
+        throw e;
+        break;
+      default:
+        throw e;
+      }
+    }
 
     *iarchive_ >> descriptor_;
 
     if (descriptor_.archive_type() != archive_type) {
       throw std::runtime_error("File \"" + filename_ +
-                               "\" is not of correct archive type");
+                               "\" is not of correct archive type. InputArchiveLoop expected \"" +
+                               ArchiveTypeToString(archive_type) +
+                               "\" found \"" +
+                               ArchiveTypeToString(descriptor_.archive_type()) + "\"."
+        );
     }
 
     if (descriptor_.archive_compression() != ArchiveCompression::None) {
@@ -83,7 +112,7 @@ private:
       } else {
         throw std::runtime_error(
             "Unsupported compression type for input archive file \"" +
-            filename_ + "\"");
+            filename_ + "\". Expected " + ArchiveCompressionToString(ArchiveCompression::Zstd) + ".");
       }
       in_->push(*ifstream_);
       iarchive_ = std::make_unique<boost::archive::binary_iarchive>(

--- a/lib/logging/BoostHelper.hpp
+++ b/lib/logging/BoostHelper.hpp
@@ -1,0 +1,35 @@
+// Copyright 2025 Florian Schintke <schintke@zib.de>
+/// \file
+/// \brief Collection of helper functions regarding boost and boost archives.
+#pragma once
+
+#include <cstdint>
+
+namespace fles {
+/**
+ * \brief Find earliest boost library supporting a given boost archive version.
+ */
+constexpr const char* boostlib_for_archive_version(uint64_t v) {
+  switch (v) {
+    // earliest boost library version known to support the given
+    // archive version according to doc/boost_serialization.txt and
+    // https://github.com/boostorg/serialization/blob/develop/src/basic_archive.cpp
+  case 10: return "1.54";
+  case 11: return "1.56";
+  case 12: return "1.58";
+  case 13: return "1.59";
+  case 14: return "1.60";
+  case 15: return "1.64";
+  case 16: return "1.66";
+  case 17: return "1.68";
+  case 18: return "1.73";
+  case 19: return "1.76";
+  case 20: return "1.84";
+  default:
+    // latest known version of boost that still uses the largest
+    // explicitly listed archive version above
+    return "newer than 1.88";
+  }
+}
+
+} // namespace fles

--- a/lib/logging/CMakeLists.txt
+++ b/lib/logging/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright 2013-2014, 2016 Jan de Cuveland <cmail@cuveland.de>
 
-add_library(logging log.cpp log.hpp)
+add_library(logging BoostHelper.hpp log.cpp log.hpp)
 
 target_compile_definitions(logging
   PUBLIC BOOST_LOG_DYN_LINK


### PR DESCRIPTION
- update the archive versions for recent boost versions
- improve error messages on version mismatch when reading InputArchives: report executable's supported archive version report newer boost library version, which may help
- improve error messages when ArchiveType is wrong: report found and expected ArchiveType
- improve error messages when CompressionType is wrong: report expected CompressionType

To achieve the functionality, we add a BoostHelper.hpp for mapping boost archive versions to boost library versions supporting them and add constexpr for the enums ArchiveType and ArchiveCompression to convert them to strings (in ArchiveDescriptor.hpp).