### PR TITLE
Fix UCX throughput: avoid iov datatype on the bulk sender->builder path

### DIFF
--- a/app/stserver/StSender.cpp
+++ b/app/stserver/StSender.cpp
@@ -3,6 +3,7 @@
    Author: Jan de Cuveland */
 
 #include "StSender.hpp"
+#include "MicrosliceDescriptor.hpp"
 #include "SubTimeslice.hpp"
 #include "TsbProtocol.hpp"
 #include "Utility.hpp"
@@ -26,30 +27,39 @@
 
 namespace {
 
-// Merge adjacent iovs that are contiguous in memory; zero-length entries are
-// dropped. Merging is transparent on the wire (a UCX send iov is a pure
-// gather list, and the builder splits the flat byte stream by sizes from the
-// header, not by iov boundaries), so in aggregation mode -- where the whole
-// payload lives in one contiguous slot -- this collapses the per-component
-// iovs into a single one, drastically reducing the iov count handed to UCX.
-void coalesce_iovs(std::vector<ucp_dt_iov>& iovs) {
-  std::size_t out = 0;
-  for (std::size_t in = 0; in < iovs.size(); ++in) {
-    const ucp_dt_iov& cur = iovs[in];
-    if (cur.length == 0) {
+// Split a component's scatter-gather list into the two transfer blocks
+// (microslice descriptors, then content) and append them to `blocks`. The
+// split position is num_microslices * sizeof(MicrosliceDescriptor), which the
+// builder derives independently from the merged descriptor to pre-post the
+// matching receives. Without aggregation the iov boundary coincides with the
+// split (descriptors and content come from different ring buffers); with
+// aggregation the single contiguous iov is split arithmetically.
+void append_component_blocks(std::vector<std::vector<ucp_dt_iov>>& blocks,
+                             const StComponentHandle& component) {
+  blocks.emplace_back();
+  blocks.emplace_back();
+  auto& desc_block = blocks[blocks.size() - 2];
+  auto& content_block = blocks[blocks.size() - 1];
+
+  uint64_t desc_remaining =
+      component.num_microslices * sizeof(fles::MicrosliceDescriptor);
+  for (ucp_dt_iov iov : component.ms_data) {
+    if (iov.length == 0) {
       continue;
     }
-    if (out > 0) {
-      ucp_dt_iov& prev = iovs[out - 1];
-      if (static_cast<std::byte*>(prev.buffer) + prev.length ==
-          static_cast<std::byte*>(cur.buffer)) {
-        prev.length += cur.length;
+    if (desc_remaining > 0) {
+      if (iov.length <= desc_remaining) {
+        desc_block.push_back(iov);
+        desc_remaining -= iov.length;
         continue;
       }
+      desc_block.push_back({iov.buffer, desc_remaining});
+      iov.buffer = static_cast<std::byte*>(iov.buffer) + desc_remaining;
+      iov.length -= desc_remaining;
+      desc_remaining = 0;
     }
-    iovs[out++] = cur;
+    content_block.push_back(iov);
   }
-  iovs.resize(out);
 }
 
 } // namespace
@@ -370,20 +380,24 @@ void StSender::do_announce_subtimeslice(TsId id, const StHandle& sth) {
   // the (merged) descriptor as part of the assignment.
   auto st_descriptor_bytes = serialize_descriptor(st_descriptor);
 
-  // Assemble a vector of ucp_dt_iov structures pointing at the (registered)
-  // microslice data blocks. With the aggregation buffer the whole payload is
-  // one contiguous block, so coalescing collapses the per-component iovs
-  // down to a single one.
-  std::vector<ucp_dt_iov> iov_vector;
+  // Assemble the scatter-gather lists of the transfer blocks (two per
+  // component) pointing at the (registered) microslice data. Each block is
+  // later sent as one tagged message into a receive the builder pre-posts
+  // from the same layout information.
+  std::vector<std::vector<ucp_dt_iov>> blocks;
   for (const auto& c : sth.components) {
-    iov_vector.insert(iov_vector.end(), c.ms_data.begin(), c.ms_data.end());
+    append_component_blocks(blocks, c);
   }
-  coalesce_iovs(iov_vector);
+  if (blocks.empty()) {
+    // No components: exchange a single zero-size message so the builder's
+    // pre-posted receive completes and the protocol stays synchronous
+    blocks.emplace_back();
+  }
 
   // Store for future use (and retention during send)
   m_announced.emplace(
       id, std::make_unique<AnnouncementHandle>(
-              id, std::move(st_descriptor_bytes), std::move(iov_vector)));
+              id, std::move(st_descriptor_bytes), std::move(blocks)));
   auto& ah = *m_announced.at(id);
 
   DEBUG("{}| Announcing ({}c, {}m, {}, flags={:04x})", id,
@@ -525,8 +539,9 @@ void StSender::send_subtimeslice_to_builder(TsId id,
                                             uint64_t tag) {
   if (!m_announced.contains(id)) {
     // Subtimeslice not found: send a zero-byte tag-matched message so the
-    // builder's pre-posted recv completes (with a length of 0 it will be
-    // marked as Failed there). This keeps the protocol synchronous.
+    // builder's first pre-posted recv completes (with a length of 0 it will
+    // be marked as Failed there and the remaining pre-posted recvs of this
+    // contribution are canceled). This keeps the protocol synchronous.
     WARN("{}| Subtimeslice not found", id);
     ucp_request_param_t req_param{};
     req_param.op_attr_mask =
@@ -542,50 +557,56 @@ void StSender::send_subtimeslice_to_builder(TsId id,
   }
   auto& ah = *m_announced.at(id);
 
-  // Prepare send parameters
-  ucp_request_param_t req_param{};
-  req_param.op_attr_mask =
-      UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
-  req_param.cb.send = on_builder_send_complete;
-  req_param.user_data = this;
+  // Send the transfer blocks as separate tagged messages, all with the same
+  // tag: tag matching is FIFO per tag, so they complete the builder's
+  // pre-posted receives in order. A block is sent with the default contiguous
+  // datatype whenever it consists of a single fragment (always the case with
+  // the aggregation buffer): for the iov datatype UCX cannot use the
+  // single-RDMA-read rendezvous protocol and falls back to fragmented sends
+  // at roughly half the achievable bandwidth. Only blocks split by a ring
+  // buffer wrap-around still use the iov datatype.
+  DEBUG("{}| Sending {} blocks to builder '{}'", id, ah.blocks.size(),
+        m_builders[ep]);
+  for (const auto& block : ah.blocks) {
+    ucp_request_param_t req_param{};
+    req_param.op_attr_mask =
+        UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
+    req_param.cb.send = on_builder_send_complete;
+    req_param.user_data = this;
 
-  // For a single contiguous block (the common case with the aggregation
-  // buffer), send with the default contiguous datatype: for the iov datatype
-  // UCX cannot use the single-RDMA-read rendezvous protocol and falls back to
-  // fragmented sends at roughly half the achievable bandwidth.
-  const void* send_buffer = nullptr;
-  size_t send_count = 0;
-  if (ah.iov_vector.size() == 1) {
-    send_buffer = ah.iov_vector[0].buffer;
-    send_count = ah.iov_vector[0].length;
-  } else {
-    req_param.op_attr_mask |= UCP_OP_ATTR_FIELD_DATATYPE;
-    req_param.datatype = ucp_dt_make_iov();
-    send_buffer = ah.iov_vector.data();
-    send_count = ah.iov_vector.size();
+    const void* send_buffer = nullptr;
+    size_t send_count = 0;
+    if (block.size() == 1) {
+      send_buffer = block[0].buffer;
+      send_count = block[0].length;
+    } else if (block.size() > 1) {
+      req_param.op_attr_mask |= UCP_OP_ATTR_FIELD_DATATYPE;
+      req_param.datatype = ucp_dt_make_iov();
+      send_buffer = block.data();
+      send_count = block.size();
+    }
+
+    ucs_status_ptr_t request =
+        ucp_tag_send_nbx(ep, send_buffer, send_count, tag, &req_param);
+
+    if (UCS_PTR_IS_ERR(request)) {
+      ucs_status_t status = UCS_PTR_STATUS(request);
+      ERROR("Failed to send tag message: {}", status);
+      // Stop sending; the builder handles the missing blocks via its timeout.
+      // Keep the announced subtimeslice.
+      return;
+    }
+
+    if (request == nullptr) {
+      // Operation has completed successfully in-place
+      continue;
+    }
+
+    // Keep the element in m_announced until the send completes and store the
+    // request
+    m_active_send_requests[request] = id;
+    ah.active_send_requests++;
   }
-
-  // Send the data
-  DEBUG("{}| Sending to builder '{}'", id, m_builders[ep]);
-  ucs_status_ptr_t request =
-      ucp_tag_send_nbx(ep, send_buffer, send_count, tag, &req_param);
-
-  if (UCS_PTR_IS_ERR(request)) {
-    ucs_status_t status = UCS_PTR_STATUS(request);
-    ERROR("Failed to send tag message: {}", status);
-    // Ignore the interaction with the builder, keep the announced subtimeslice
-    return;
-  }
-
-  if (request == nullptr) {
-    // Operation has completed successfully in-place
-    return;
-  }
-
-  // Keep the element in m_announced until the send completes and store the
-  // request
-  m_active_send_requests[request] = id;
-  ah.active_send_requests++;
 }
 
 void StSender::handle_builder_send_complete(void* request,

--- a/app/stserver/StSender.cpp
+++ b/app/stserver/StSender.cpp
@@ -544,17 +544,31 @@ void StSender::send_subtimeslice_to_builder(TsId id,
 
   // Prepare send parameters
   ucp_request_param_t req_param{};
-  req_param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
-                           UCP_OP_ATTR_FIELD_USER_DATA |
-                           UCP_OP_ATTR_FIELD_DATATYPE;
+  req_param.op_attr_mask =
+      UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
   req_param.cb.send = on_builder_send_complete;
   req_param.user_data = this;
-  req_param.datatype = ucp_dt_make_iov();
+
+  // For a single contiguous block (the common case with the aggregation
+  // buffer), send with the default contiguous datatype: for the iov datatype
+  // UCX cannot use the single-RDMA-read rendezvous protocol and falls back to
+  // fragmented sends at roughly half the achievable bandwidth.
+  const void* send_buffer = nullptr;
+  size_t send_count = 0;
+  if (ah.iov_vector.size() == 1) {
+    send_buffer = ah.iov_vector[0].buffer;
+    send_count = ah.iov_vector[0].length;
+  } else {
+    req_param.op_attr_mask |= UCP_OP_ATTR_FIELD_DATATYPE;
+    req_param.datatype = ucp_dt_make_iov();
+    send_buffer = ah.iov_vector.data();
+    send_count = ah.iov_vector.size();
+  }
 
   // Send the data
   DEBUG("{}| Sending to builder '{}'", id, m_builders[ep]);
-  ucs_status_ptr_t request = ucp_tag_send_nbx(
-      ep, ah.iov_vector.data(), ah.iov_vector.size(), tag, &req_param);
+  ucs_status_ptr_t request =
+      ucp_tag_send_nbx(ep, send_buffer, send_count, tag, &req_param);
 
   if (UCS_PTR_IS_ERR(request)) {
     ucs_status_t status = UCS_PTR_STATUS(request);

--- a/app/stserver/StSender.hpp
+++ b/app/stserver/StSender.hpp
@@ -32,9 +32,9 @@ using namespace std::chrono_literals;
 struct AnnouncementHandle {
   AnnouncementHandle(TsId id,
                      std::vector<std::byte> st_descriptor_bytes,
-                     std::vector<ucp_dt_iov> iov_vector)
+                     std::vector<std::vector<ucp_dt_iov>> blocks)
       : id(id), st_descriptor_bytes(std::move(st_descriptor_bytes)),
-        iov_vector(std::move(iov_vector)) {}
+        blocks(std::move(blocks)) {}
 
   // Cannot be moved or copied (pointer to data is used by ucx)
   AnnouncementHandle(const AnnouncementHandle&) = delete;
@@ -42,7 +42,9 @@ struct AnnouncementHandle {
 
   const TsId id;
   std::vector<std::byte> st_descriptor_bytes;
-  std::vector<ucp_dt_iov> iov_vector;
+  /// Scatter-gather lists of the transfer blocks (two per component:
+  /// microslice descriptors, then content), each sent as one tagged message
+  std::vector<std::vector<ucp_dt_iov>> blocks;
   size_t active_send_requests = 0;
   bool pending_release = false;
 };

--- a/app/tsbuilder/TsBuilder.cpp
+++ b/app/tsbuilder/TsBuilder.cpp
@@ -249,14 +249,10 @@ void TsBuilder::check_for_timeout(TsId id) {
     for (std::size_t i = 0; i < tsh.states.size(); ++i) {
       if (tsh.states[i] == StState::Requested ||
           tsh.states[i] == StState::Receiving) {
-        // Cancel potential ongoing receive operation
-        for (const auto& [request, req_id] : m_active_data_recv_requests) {
-          if (req_id.first == id && req_id.second == i) {
-            ucp_request_cancel(m_worker, request);
-            DEBUG("{}|s{}/{}| Canceling receive operation", id, i,
-                  tsh.sender_ids.size());
-          }
-        }
+        // Cancel potential ongoing receive operations
+        DEBUG("{}|s{}/{}| Canceling receive operations", id, i,
+              tsh.sender_ids.size());
+        cancel_data_recvs(id, i);
       }
     }
   }
@@ -314,11 +310,15 @@ ucs_status_t TsBuilder::handle_scheduler_assign_ts(
   // BEFORE asking senders for the contributions, so the recvs are "expected"
   // by the time the senders start sending (no rendezvous CTS round-trip).
   for (std::size_t i = 0; i < tsh.sender_ids.size(); ++i) {
-    post_tag_recv(tsh, i);
+    post_tag_recvs(tsh, i);
   }
 
   // Ask senders for the contributions
   for (std::size_t i = 0; i < tsh.sender_ids.size(); ++i) {
+    if (tsh.states[i] != StState::Allocated) {
+      // Posting the receives failed; do not trigger unmatched sends
+      continue;
+    }
     send_request_to_sender(tsh.sender_ids[i], id, i);
     update_st_state(tsh, i, StState::Requested);
   }
@@ -393,36 +393,66 @@ void TsBuilder::disconnect_from_senders() {
 
 // Sender message handling
 
-void TsBuilder::post_tag_recv(TsHandle& tsh, std::size_t ci) {
+void TsBuilder::post_tag_recvs(TsHandle& tsh, std::size_t ci) {
   const ucp_tag_t tag = make_st_data_tag(tsh.id, static_cast<uint32_t>(ci));
   const ucp_tag_t tag_mask = ~ucp_tag_t{0}; // exact match
 
-  ucp_request_param_t req_param{};
-  req_param.op_attr_mask =
-      UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
-  req_param.cb.recv = on_sender_data_recv_complete;
-  req_param.user_data = this;
+  // Post one receive per transfer block, all with the same tag: tag matching
+  // is FIFO per tag, and the sender sends the blocks in the same order.
+  for (const auto& block : tsh.blocks[ci]) {
+    ucp_request_param_t req_param{};
+    req_param.op_attr_mask =
+        UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
+    req_param.cb.recv = on_sender_data_recv_complete;
+    req_param.user_data = this;
 
-  ucs_status_ptr_t request =
-      ucp_tag_recv_nbx(m_worker, tsh.buffer + tsh.offsets[ci],
-                       tsh.ms_data_sizes[ci], tag, tag_mask, &req_param);
+    ucs_status_ptr_t request =
+        ucp_tag_recv_nbx(m_worker, tsh.buffer + block.offset, block.size, tag,
+                         tag_mask, &req_param);
 
-  if (UCS_PTR_IS_ERR(request)) {
-    ucs_status_t status = UCS_PTR_STATUS(request);
-    ERROR("{}|s{}/{}| Failed to post tag recv: {}", tsh.id, ci,
-          tsh.sender_ids.size(), status);
-    update_st_state(tsh, ci, StState::Failed);
-    return;
+    if (UCS_PTR_IS_ERR(request)) {
+      ucs_status_t status = UCS_PTR_STATUS(request);
+      ERROR("{}|s{}/{}| Failed to post tag recv: {}", tsh.id, ci,
+            tsh.sender_ids.size(), status);
+      update_st_state(tsh, ci, StState::Failed);
+      cancel_data_recvs(tsh.id, ci);
+      return;
+    }
+
+    if (request == nullptr) {
+      // Already completed (shouldn't normally happen for a pre-posted recv
+      // since the matching send hasn't been requested yet, but handle it).
+      complete_block(tsh, ci);
+      continue;
+    }
+
+    m_active_data_recv_requests[request] = {tsh.id, ci, block.size};
   }
+}
 
-  if (request == nullptr) {
-    // Already completed (shouldn't normally happen for a pre-posted recv
-    // since the matching send hasn't been requested yet, but handle it).
+// Cancel all outstanding data receive operations of one contribution.
+// Collect the requests first: ucp_request_cancel may invoke the completion
+// callback inline, which erases from m_active_data_recv_requests.
+void TsBuilder::cancel_data_recvs(TsId id, std::size_t ci) {
+  std::vector<ucs_status_ptr_t> to_cancel;
+  for (const auto& [request, info] : m_active_data_recv_requests) {
+    if (info.id == id && info.ci == ci) {
+      to_cancel.push_back(request);
+    }
+  }
+  for (auto* request : to_cancel) {
+    ucp_request_cancel(m_worker, request);
+  }
+}
+
+// Account for a completed transfer block; the contribution is complete when
+// all of its blocks have been received.
+void TsBuilder::complete_block(TsHandle& tsh, std::size_t ci) {
+  assert(tsh.blocks_remaining[ci] > 0);
+  if (--tsh.blocks_remaining[ci] == 0) {
+    m_component_count++;
     update_st_state(tsh, ci, StState::Complete);
-    return;
   }
-
-  m_active_data_recv_requests[request] = {tsh.id, ci};
 }
 
 void TsBuilder::send_request_to_sender(const std::string& sender_id,
@@ -465,7 +495,7 @@ void TsBuilder::handle_sender_data_recv_complete(
   if (!m_active_data_recv_requests.contains(request)) {
     ERROR("Received completion for unknown data recv request");
   } else {
-    auto [id, ci] = m_active_data_recv_requests.at(request);
+    auto [id, ci, expected_size] = m_active_data_recv_requests.at(request);
     m_active_data_recv_requests.erase(request);
 
     if (!m_ts_handles.contains(id)) {
@@ -484,16 +514,19 @@ void TsBuilder::handle_sender_data_recv_complete(
       }
       return;
     }
-    if (status != UCS_OK || length != tsh.ms_data_sizes[ci]) {
+    if (status != UCS_OK || length != expected_size) {
       if (status == UCS_OK) {
-        ERROR("{}|s{}/{}| Unexpected received length: expected {}, got {}", id,
-              ci, tsh.sender_ids.size(), tsh.ms_data_sizes[ci], length);
+        ERROR("{}|s{}/{}| Unexpected received block length: expected {}, "
+              "got {}",
+              id, ci, tsh.sender_ids.size(), expected_size, length);
       }
       update_st_state(tsh, ci, StState::Failed);
+      // Cancel the remaining pre-posted receives of this contribution (e.g.,
+      // after the zero-size "not found" reply from the sender)
+      cancel_data_recvs(id, ci);
     } else {
-      m_component_count++;
       m_byte_count += length;
-      update_st_state(tsh, ci, StState::Complete);
+      complete_block(tsh, ci);
     }
   }
 

--- a/app/tsbuilder/TsBuilder.hpp
+++ b/app/tsbuilder/TsBuilder.hpp
@@ -3,6 +3,7 @@
    Author: Jan de Cuveland */
 #pragma once
 
+#include "MicrosliceDescriptor.hpp"
 #include "Monitor.hpp"
 #include "Scheduler.hpp"
 #include "SubTimeslice.hpp"
@@ -53,6 +54,13 @@ inline std::string to_string(StState state) {
   }
 }
 
+/// A contiguous destination range within the timeslice buffer, received as
+/// one tagged message
+struct StDataBlock {
+  uint64_t offset = 0; ///< absolute offset within the timeslice buffer
+  uint64_t size = 0;
+};
+
 struct TsHandle {
   TsHandle(std::byte* buffer, StCollection contributions)
       : id(contributions.id), allocated_at_ns(fles::system::current_time_ns()),
@@ -70,6 +78,43 @@ struct TsHandle {
     std::fill(states.begin(), states.end(), StState::Allocated);
     std::fill(state_change_at_ns.begin(), state_change_at_ns.end(),
               allocated_at_ns);
+    // Derive the per-contribution transfer block layout: each component
+    // arrives as two contiguous tagged messages (microslice descriptors, then
+    // content). The sender derives the identical layout from its announced
+    // descriptor, of which the merged descriptor contains a copy with
+    // absolute offsets, components in sender order.
+    blocks.resize(sender_ids.size());
+    blocks_remaining.resize(sender_ids.size(), 0);
+    std::size_t comp = 0; // running index into merged_descriptor.components
+    for (std::size_t ci = 0; ci < sender_ids.size(); ++ci) {
+      uint64_t remaining = ms_data_sizes[ci];
+      uint64_t pos = offsets[ci];
+      while (remaining > 0 && comp < merged_descriptor.components.size()) {
+        const auto& c = merged_descriptor.components[comp];
+        const uint64_t desc_size =
+            c.num_microslices * sizeof(fles::MicrosliceDescriptor);
+        if (static_cast<uint64_t>(c.ms_data_offset) != pos ||
+            c.ms_data_size < desc_size || c.ms_data_size > remaining) {
+          break; // inconsistent component metadata, use fallback below
+        }
+        blocks[ci].push_back({pos, desc_size});
+        blocks[ci].push_back({pos + desc_size, c.ms_data_size - desc_size});
+        pos += c.ms_data_size;
+        remaining -= c.ms_data_size;
+        ++comp;
+      }
+      if (remaining > 0) {
+        // Inconsistent or missing component metadata: fall back to a single
+        // full-size block (the transfer will fail via the timeout if the
+        // sender disagrees)
+        blocks[ci].assign(1, {offsets[ci], ms_data_sizes[ci]});
+      } else if (blocks[ci].empty()) {
+        // Empty contribution: the sender sends a single zero-size message to
+        // keep the protocol synchronous
+        blocks[ci].assign(1, {offsets[ci], 0});
+      }
+      blocks_remaining[ci] = blocks[ci].size();
+    }
   }
 
   // Cannot be moved or copied (pointer to data is used by ucx)
@@ -86,6 +131,8 @@ struct TsHandle {
   std::vector<uint64_t> offsets;
   std::vector<StState> states;
   std::vector<uint64_t> state_change_at_ns;
+  std::vector<std::vector<StDataBlock>> blocks; ///< per contribution
+  std::vector<std::size_t> blocks_remaining;    ///< per contribution
   bool is_published = false;
 };
 
@@ -125,7 +172,12 @@ private:
   std::unordered_map<ucp_ep_h, std::string> m_ep_to_sender;
 
   std::unordered_map<TsId, std::unique_ptr<TsHandle>> m_ts_handles;
-  std::unordered_map<ucs_status_ptr_t, std::pair<TsId, std::size_t>>
+  struct RecvRequestInfo {
+    TsId id = 0;
+    std::size_t ci = 0;
+    uint64_t expected_size = 0;
+  };
+  std::unordered_map<ucs_status_ptr_t, RecvRequestInfo>
       m_active_data_recv_requests;
 
   static constexpr auto m_scheduler_retry_interval = 2s;
@@ -164,7 +216,9 @@ private:
   void disconnect_from_senders();
 
   // Sender message handling
-  void post_tag_recv(TsHandle& tsh, std::size_t ci);
+  void post_tag_recvs(TsHandle& tsh, std::size_t ci);
+  void cancel_data_recvs(TsId id, std::size_t ci);
+  void complete_block(TsHandle& tsh, std::size_t ci);
   void
   send_request_to_sender(const std::string& sender_id, TsId id, std::size_t ci);
   void handle_sender_data_recv_complete(void* request,

--- a/lib/tsb/TsbProtocol.hpp
+++ b/lib/tsb/TsbProtocol.hpp
@@ -49,12 +49,22 @@ static constexpr unsigned int AM_BUILDER_REQUEST_ST =
     60; // header: {StId, tag}, data: none
 //
 // The actual bulk transfer stsender -> tsbuilder uses UCX tag matching
-// (ucp_tag_send_nbx / ucp_tag_recv_nbx), not an active message. The builder
-// pre-posts the receive into its registered timeslice buffer immediately
-// after receiving AM_SCHED_ASSIGN_TS and before issuing the request to the
-// sender, so the recv is "expected" by the time the sender starts the send,
-// allowing UCX to skip the rendezvous CTS round-trip and (with put_zcopy)
-// issue an RDMA WRITE directly into the target buffer.
+// (ucp_tag_send_nbx / ucp_tag_recv_nbx), not an active message. A
+// contribution is transferred as a sequence of contiguous blocks -- two per
+// component: the microslice descriptors, then the content -- each sent as
+// one tagged message. All blocks of a contribution use the same tag; tag
+// matching is FIFO per tag, so they complete the builder's pre-posted
+// receives in order. Both sides derive the identical block layout
+// independently: the sender from its announced descriptor, the builder from
+// the merged descriptor relayed by the scheduler (descriptor block size =
+// num_microslices * sizeof(MicrosliceDescriptor)). Contiguous blocks are
+// sent with the default (contiguous) UCX datatype, which allows the
+// single-RDMA-read rendezvous protocol; the iov datatype would force UCX
+// into fragmented sends at roughly half the achievable bandwidth. The
+// builder pre-posts the receives into its registered timeslice buffer
+// immediately after receiving AM_SCHED_ASSIGN_TS and before issuing the
+// request to the sender, so the recvs are "expected" by the time the sender
+// starts sending, avoiding the rendezvous CTS round-trip.
 
 // Tag encoding for the bulk sender->builder transfer.
 // Layout: high 48 bits = TsId, low 16 bits = contribution (sender) index


### PR DESCRIPTION
## Summary

Closes the ~2.5x throughput gap between the stserver→tsbuilder data path and raw `ib_write_bw`/`ucx_perftest` numbers, for both operation modes.

**Root cause:** `send_subtimeslice_to_builder` always sent with the UCX iov datatype (`ucp_dt_make_iov`). For iov sends, UCX (1.20, proto v2) cannot use the single-RDMA-read rendezvous protocol ("rendezvous zero-copy read from remote") and instead selects "rendezvous data send" — sender-side fragmented sends. `UCX_PROTO_INFO=y` on a live run shows the two protocol tables side by side; forcing `UCX_RNDV_SCHEME=put_zcopy` does not help. This happened even for a **single-entry** iov (the common case with the default-on contiguous aggregation buffer).

## Commits

1. **Avoid iov datatype for single-block sends to builder** — when the coalesced iov has exactly one entry, send with the default contiguous datatype.
2. **Transfer subtimeslices as per-component contiguous blocks** — protocol change that extends the fast path to scatter-gather mode (`--aggregation-buffer-size 0`): each contribution is sent as a sequence of tagged messages, two per component (microslice descriptor block, then content block), all sharing one tag. Tag matching is FIFO per tag, so they complete the builder's pre-posted receives in order. Both sides derive the identical block layout independently (descriptor block size = `num_microslices * sizeof(MicrosliceDescriptor)`): the sender from its announced subtimeslice, the builder from the merged descriptor relayed by the scheduler. Only blocks split by a ring-buffer wrap-around still use the iov datatype. On any failed/short block receive the builder cancels the contribution's remaining receives, preserving the synchronous zero-byte "not found" handshake.

## Measurements (node8→node9, single rail `UCX_NET_DEVICES=ibp24s0:1`, pgen source)

| Mode | before | after |
|---|---|---|
| aggregation buffer (102 MB / 204 MB contributions) | ~4.6 GB/s | **~11.6–12 GB/s** (= `ucx_perftest`/`ib_write_bw`) |
| scatter-gather, `--aggregation-buffer-size 0` (204 MB, 4 components) | ~4.4 GB/s | **~9.5–10 GB/s** |
| aggregation, unpinned (default devices) | — | ~25 GB/s (UCX stripes across 2 rails) |

The remaining scatter-gather deficit vs. the aggregated path appears to be source-memory-related (shm ring buffers vs. heap aggregation buffer), not protocol-related.

## Verification

- `UCX_PROTO_INFO=y` confirms content blocks use "rendezvous zero-copy read from remote"; wrapped blocks appear as `iov[2]` sends as designed.
- Data integrity verified end-to-end in **both modes**: pgen ramp pattern (`--pgen-flags 1`) and per-microslice CRCs validated directly in the builder's shm buffer (descriptor fields, full content bytes, CRC — 814 microslices per run, zero errors).
- No incomplete timeslices, no errors in any verification run; original single-channel config re-checked for regressions (8–9 ms per 102 MB, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)