### PR TITLE
Fix use-after-free when cancelling receives re-entrantly in TsBuilder

### DIFF
--- a/app/tsbuilder/TsBuilder.cpp
+++ b/app/tsbuilder/TsBuilder.cpp
@@ -432,6 +432,9 @@ void TsBuilder::post_tag_recvs(TsHandle& tsh, std::size_t ci) {
 // Cancel all outstanding data receive operations of one contribution.
 // Collect the requests first: ucp_request_cancel may invoke the completion
 // callback inline, which erases from m_active_data_recv_requests.
+// That callback can also re-enter this function and cancel (and free) the
+// remaining requests of the contribution, so re-check every request against
+// the map before cancelling it.
 void TsBuilder::cancel_data_recvs(TsId id, std::size_t ci) {
   std::vector<ucs_status_ptr_t> to_cancel;
   for (const auto& [request, info] : m_active_data_recv_requests) {
@@ -440,7 +443,9 @@ void TsBuilder::cancel_data_recvs(TsId id, std::size_t ci) {
     }
   }
   for (auto* request : to_cancel) {
-    ucp_request_cancel(m_worker, request);
+    if (m_active_data_recv_requests.contains(request)) {
+      ucp_request_cancel(m_worker, request);
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

`cancel_data_recvs()` snapshots the matching requests into a vector before cancelling them, because `ucp_request_cancel` may invoke the completion callback inline and that callback erases from `m_active_data_recv_requests`.

But the callback does more than erase. On a failed or cancelled block, `handle_sender_data_recv_complete()` calls `cancel_data_recvs()` again for the same contribution, which cancels *and frees* the remaining requests. When the outer loop resumes, it calls `ucp_request_cancel` on requests that have already been freed:

1. `check_for_timeout` → `cancel_data_recvs(id, ci)` snapshots `[A, B, C]`
2. cancels `A` → inline callback → state `Failed` → nested `cancel_data_recvs(id, ci)` snapshots `[B, C]`, cancels and frees both
3. unwind; the outer loop now calls `ucp_request_cancel` on the freed `B` and `C`

Since the per-component block protocol (30c6df1) a contribution holds several requests, so a build timeout on a multi-block contribution can hit this.

## Fix

Re-check each request against `m_active_data_recv_requests` before cancelling it. The callback removes the map entry before freeing the request, so a missing entry reliably means the request is gone.

## Context

Found while investigating a `tsbuilder` `CrashLoopBackOff` on the Kubernetes test setup. The crash observed there was the *earlier* variant of this bug — cancelling while iterating the map directly, invalidating the iterator — which was already fixed by 30c6df1; those pods were running an older build. The remaining re-entrancy hole is what this PR closes.

The build timeouts that triggered the cancellations in the first place were caused by broken pod-to-pod routing between the two nodes, not by flesnet.

## Test plan

- [x] `tsbuilder` compiles cleanly (RelWithDebInfo, UCX 1.20.0)
- [ ] Not reproduced on hardware; the path needs a build timeout on a multi-block contribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)