### PR TITLE
Remove a stale shared memory segment on stserver startup

### DIFF
--- a/app/stserver/StBuilder.cpp
+++ b/app/stserver/StBuilder.cpp
@@ -110,6 +110,10 @@ StBuilder::StBuilder(volatile sig_atomic_t* signal_status,
                         (m_cri_channels.size() + pgen_channels) +
                     4096;
 
+  // remove a segment left behind by a previous process that did not shut down
+  // cleanly, as create_only would fail on it
+  boost::interprocess::shared_memory_object::remove(m_shm_id.c_str());
+
   INFO("Creating shared memory segment '{}' of size {}", m_shm_id,
        human_readable_count(shm_size, true));
   m_shm = std::make_unique<boost::interprocess::managed_shared_memory>(


### PR DESCRIPTION
`stserver` creates its shared memory segment with `create_only` and removes it only in the destructor (`StBuilder.cpp`). A process that is killed rather than shut down cleanly therefore leaves the segment behind, and every subsequent start fails:

```
INFO: Creating shared memory segment 'test_stale_shm' of size 1.091 GB
FATAL: File exists
```

Recovering from this needs a manual `rm` in `/dev/shm` on the affected node, which is easy to miss when a run fails to start.

Remove the segment before creating it, which is what `tsbuilder` already does in `TsBuffer::TsBuffer()`.

Note that this only affects unclean termination. A normal stop is fine: `SIGTERM` is handled in `main.cpp` and the run loop checks the flag, so the destructor runs and removes the segment as before.

### Testing

Verified in both directions with `-P1`, so no CRI is involved:

- Without the change, with a stale segment in place, startup aborts with `FATAL: File exists` and the segment is left untouched.
- With the change, the stale segment is replaced by the real one and startup proceeds.
- A clean `SIGTERM` still exits 0 and logs `Removing shared memory segment`.