### PR TITLE
Let consumers pick the C++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,14 @@ if(USE_CLANG_TIDY)
   endif()
 endif()
 
-set(CMAKE_CXX_STANDARD 23)
+# C++23 unless a consumer explicitly requests otherwise. Projects embedding the
+# externally consumed libraries (logging, monitoring, fles_ipc, shm_ipc,
+# tsclient) may still be on an older toolchain and can pass
+# -DCMAKE_CXX_STANDARD=17. Targets that genuinely need C++23 declare it via
+# target_compile_features().
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 23)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if( NOT "arm64" STREQUAL ${CMAKE_SYSTEM_PROCESSOR} )

--- a/app/tsmanager/CMakeLists.txt
+++ b/app/tsmanager/CMakeLists.txt
@@ -9,6 +9,9 @@ add_executable(tsmanager
   TsManager.cpp
 )
 
+# Uses std::format, independent of the global default
+target_compile_features(tsmanager PRIVATE cxx_std_23)
+
 target_include_directories(tsmanager
   SYSTEM PUBLIC ${Boost_INCLUDE_DIRS}
 )

--- a/lib/logging/log.hpp
+++ b/lib/logging/log.hpp
@@ -6,7 +6,11 @@
 #include <boost/log/common.hpp>
 #include <boost/log/sinks/syslog_backend.hpp>
 #include <boost/log/utility/manipulators/to_log.hpp>
+// Only required by the LF()/ERROR()/... macros below. Guarded so that this
+// header stays includable from C++17 consumers and pre-13 libstdc++.
+#if __has_include(<format>)
 #include <format>
+#endif
 #include <iosfwd>
 #include <iostream>
 

--- a/lib/tsb/CMakeLists.txt
+++ b/lib/tsb/CMakeLists.txt
@@ -7,6 +7,9 @@ file(GLOB LIB_HEADERS *.hpp)
 
 add_library(tsb ${LIB_SOURCES} ${LIB_HEADERS})
 
+# Uses std::format and other C++23 features, independent of the global default
+target_compile_features(tsb PUBLIC cxx_std_23)
+
 target_include_directories(tsb PUBLIC .)
 
 target_include_directories(fles_core SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
Flesnet hard-set `CMAKE_CXX_STANDARD 23`, overriding what an embedding project passes in. CbmRoot builds `logging`, `monitoring`, `fles_ipc` and `tsclient` as an ExternalProject and already passes its own standard (default 17), which was silently ignored.

Now the default only applies if the consumer did not set one. `tsb` and `tsmanager` request `cxx_std_23` via `target_compile_features`, and `log.hpp` guards its `<format>` include for pre-13 libstdc++.

Verified with g++-14:

- default build unchanged, all 107 targets
- with `-DCMAKE_CXX_STANDARD=17` the whole tree builds; the consumed modules compile as `gnu++17`, `tsb`/`tsmanager` as `gnu++23`

Note: the `<format>` guard holds because no C++17-compiled source expands the `LF()`/`INFO()`/... macros today. Adding one to a consumed module would break the CbmRoot build at the use site.